### PR TITLE
feat(ui): redesign with classy Pinterest pastel rose style

### DIFF
--- a/src/app/features/auth/pages/login/login.component.ts
+++ b/src/app/features/auth/pages/login/login.component.ts
@@ -14,23 +14,23 @@ import { Subject, takeUntil } from 'rxjs';
   imports: [CommonModule, RouterLink],
   template: `
     <div class="container mx-auto px-4 py-12">
-      <div class="max-w-md mx-auto bg-white rounded-lg shadow-lg p-8 text-center">
-        <h1 class="text-3xl font-bold mb-4">Sign in</h1>
-        <p class="text-slate-600 mb-6">
+      <div class="max-w-md mx-auto pinterest-panel p-8 text-center">
+        <h1 class="text-3xl font-bold mb-4 text-[var(--primary)]">Sign in</h1>
+        <p class="text-[var(--text-muted)] mb-6">
           This app uses <strong>YunoHost single sign-on</strong>. Open the user portal and sign in there, then return
           to this site.
         </p>
         <a
-          class="inline-block w-full bg-[var(--accent)] text-[var(--primary)] py-3 rounded font-semibold hover:brightness-95 transition"
+          class="inline-block w-full bg-[var(--secondary)] text-white py-3 rounded-full font-semibold hover:brightness-95 transition shadow-sm"
           [href]="ssoLoginUrl"
         >
           Open YunoHost portal
         </a>
-        <p class="mt-6 text-sm text-slate-500">
+        <p class="mt-6 text-sm text-[var(--text-muted)]">
           After signing in at the portal, reload this page or navigate home.
         </p>
         <p class="mt-4 text-sm">
-          <a routerLink="/" class="text-blue-600 hover:underline">Back to home</a>
+          <a routerLink="/" class="text-[var(--accent-strong)] hover:underline">Back to home</a>
         </p>
       </div>
     </div>

--- a/src/app/features/auth/pages/register/register.component.ts
+++ b/src/app/features/auth/pages/register/register.component.ts
@@ -14,24 +14,27 @@ import { Subject, takeUntil } from 'rxjs';
   imports: [CommonModule, RouterLink],
   template: `
     <div class="container mx-auto px-4 py-12">
-      <div class="max-w-md mx-auto bg-white rounded-lg shadow-lg p-8 text-center">
-        <h1 class="text-3xl font-bold mb-4">Create an account</h1>
-        <p class="text-slate-600 mb-6">
+      <div class="max-w-md mx-auto pinterest-panel p-8 text-center">
+        <span class="inline-block px-3 py-1 rounded-full bg-[var(--surface-alt)] text-[var(--primary)] text-xs font-semibold mb-4">
+          Join the community
+        </span>
+        <h1 class="text-3xl font-bold mb-4 text-[var(--text-dark)]">Create an account</h1>
+        <p class="text-[var(--text-muted)] mb-6">
           User accounts are managed by <strong>YunoHost</strong>. Ask your server administrator to create a user, or use
           the admin tools on your server.
         </p>
         <a
-          class="inline-block w-full bg-[var(--accent)] text-[var(--primary)] py-3 rounded font-semibold hover:brightness-95 transition mb-4"
+          class="inline-block w-full bg-[var(--secondary)] text-white py-3 rounded-full font-semibold hover:brightness-95 transition mb-4"
           [href]="ssoLoginUrl"
         >
           Open YunoHost portal
         </a>
-        <p class="text-sm">
+        <p class="text-sm text-[var(--text-muted)]">
           Already have an account?
-          <a routerLink="/auth/login" class="text-blue-600 hover:underline font-semibold">Sign in</a>
+          <a routerLink="/auth/login" class="text-[var(--accent-strong)] hover:underline font-semibold">Sign in</a>
         </p>
         <p class="mt-4 text-sm">
-          <a routerLink="/" class="text-blue-600 hover:underline">Back to home</a>
+          <a routerLink="/" class="text-[var(--accent-strong)] hover:underline">Back to home</a>
         </p>
       </div>
     </div>

--- a/src/app/features/blog/pages/about/about.component.ts
+++ b/src/app/features/blog/pages/about/about.component.ts
@@ -7,9 +7,14 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   selector: 'app-about',
   standalone: true,
   template: `
-    <div class="container mx-auto px-4 py-8">
-      <h1 class="text-4xl font-bold mb-8">About Us</h1>
-      <p class="text-lg text-gray-600">About content coming soon...</p>
+    <div class="page-container">
+      <div class="pinterest-panel p-8 md:p-10">
+        <h1 class="text-4xl font-semibold mb-5 text-[var(--text-dark)]">About us</h1>
+        <p class="text-lg text-[var(--text-muted)] leading-relaxed">
+          We created this space for readers who love sharing thoughtful book reviews in a clean, inspiring
+          environment.
+        </p>
+      </div>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/blog/pages/blog-home/blog-home.component.ts
+++ b/src/app/features/blog/pages/blog-home/blog-home.component.ts
@@ -11,7 +11,7 @@ import { RouterLink } from '@angular/router';
   template: `
     <div class="container mx-auto px-4 py-10">
       <header class="mb-8">
-        <h1 class="text-4xl md:text-5xl font-bold text-[var(--primary)] mb-3">Blog</h1>
+        <h1 class="luxe-title text-4xl md:text-5xl font-bold text-[var(--primary)] mb-3">Blog</h1>
         <p class="text-lg text-[var(--text-muted)]">
           Discover our editorial world and join the community of readers.
         </p>

--- a/src/app/features/blog/pages/blog-home/blog-home.component.ts
+++ b/src/app/features/blog/pages/blog-home/blog-home.component.ts
@@ -9,14 +9,48 @@ import { RouterLink } from '@angular/router';
   standalone: true,
   imports: [RouterLink],
   template: `
-    <div class="container mx-auto px-4 py-8">
-      <h1 class="text-4xl font-bold mb-8">Blog</h1>
-      <p class="text-lg text-gray-600 mb-6">Welcome to our blog. Find out more about us and how to contribute.</p>
-      <ul class="space-y-2">
-        <li><a routerLink="/blog/about" class="text-blue-600 hover:underline">About</a></li>
-        <li><a routerLink="/blog/contribute" class="text-blue-600 hover:underline">How to contribute</a></li>
-        <li><a routerLink="/blog/contact" class="text-blue-600 hover:underline">Contact</a></li>
-      </ul>
+    <div class="container mx-auto px-4 py-10">
+      <header class="mb-8">
+        <h1 class="text-4xl md:text-5xl font-bold text-[var(--primary)] mb-3">Blog</h1>
+        <p class="text-lg text-[var(--text-muted)]">
+          Discover our editorial world and join the community of readers.
+        </p>
+      </header>
+
+      <div class="columns-1 md:columns-2 gap-6 [column-fill:_balance] space-y-6">
+        <article class="break-inside-avoid mb-6 bg-white/95 border border-[var(--border-light)] rounded-3xl p-6 shadow-[0_18px_45px_-35px_rgba(122,54,95,0.7)]">
+          <p class="text-xs uppercase tracking-[0.25em] text-[var(--text-muted)] mb-2">Who we are</p>
+          <h2 class="text-2xl font-semibold text-[var(--primary)] mb-2">About</h2>
+          <p class="text-[var(--text-muted)] mb-5">
+            Learn the story behind this classy and minimalist review platform.
+          </p>
+          <a routerLink="/blog/about" class="font-semibold text-[var(--accent-strong)] hover:text-[var(--primary)]">
+            Read more →
+          </a>
+        </article>
+
+        <article class="break-inside-avoid mb-6 bg-white/95 border border-[var(--border-light)] rounded-3xl p-6 shadow-[0_18px_45px_-35px_rgba(122,54,95,0.7)]">
+          <p class="text-xs uppercase tracking-[0.25em] text-[var(--text-muted)] mb-2">Contribute</p>
+          <h2 class="text-2xl font-semibold text-[var(--primary)] mb-2">How to contribute</h2>
+          <p class="text-[var(--text-muted)] mb-5">
+            Share your literary perspective and publish refined reviews in a few steps.
+          </p>
+          <a routerLink="/blog/contribute" class="font-semibold text-[var(--accent-strong)] hover:text-[var(--primary)]">
+            Open guide →
+          </a>
+        </article>
+
+        <article class="break-inside-avoid mb-6 bg-white/95 border border-[var(--border-light)] rounded-3xl p-6 shadow-[0_18px_45px_-35px_rgba(122,54,95,0.7)]">
+          <p class="text-xs uppercase tracking-[0.25em] text-[var(--text-muted)] mb-2">Get in touch</p>
+          <h2 class="text-2xl font-semibold text-[var(--primary)] mb-2">Contact</h2>
+          <p class="text-[var(--text-muted)] mb-5">
+            Questions, ideas or partnerships? Reach out and we will answer quickly.
+          </p>
+          <a routerLink="/blog/contact" class="font-semibold text-[var(--accent-strong)] hover:text-[var(--primary)]">
+            Contact us →
+          </a>
+        </article>
+      </div>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/blog/pages/contact/contact.component.ts
+++ b/src/app/features/blog/pages/contact/contact.component.ts
@@ -7,9 +7,13 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   selector: 'app-contact',
   standalone: true,
   template: `
-    <div class="container mx-auto px-4 py-8">
-      <h1 class="text-4xl font-bold mb-8">Contact</h1>
-      <p class="text-lg text-gray-600">Contact form coming soon...</p>
+    <div class="container mx-auto px-4 py-10">
+      <section class="max-w-3xl mx-auto pinterest-panel p-8 md:p-10">
+        <h1 class="text-4xl font-bold mb-4 text-[var(--text-dark)]">Contact</h1>
+        <p class="text-base md:text-lg text-[var(--text-muted)]">
+          Contact form coming soon...
+        </p>
+      </section>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/blog/pages/contribution-guide/contribution-guide.component.ts
+++ b/src/app/features/blog/pages/contribution-guide/contribution-guide.component.ts
@@ -11,40 +11,51 @@ import { RouterLink } from '@angular/router';
   standalone: true,
   imports: [CommonModule, RouterLink],
   template: `
-    <div class="container mx-auto px-4 py-8 max-w-3xl">
-      <a routerLink="/blog" class="text-blue-600 hover:text-blue-800 mb-6 inline-block">← Back to Blog</a>
+    <div class="page-container max-w-3xl">
+      <a
+        routerLink="/blog"
+        class="inline-flex items-center rounded-full border border-[var(--border-light)] bg-white px-4 py-2 text-sm font-semibold text-[var(--accent-strong)] shadow-sm transition hover:border-[var(--secondary)]"
+      >
+        ← Back to Blog
+      </a>
 
-      <h1 class="text-4xl font-bold mb-6">Contribution Guide</h1>
-      <p class="text-lg text-gray-600 mb-8">
-        We welcome book reviews from all readers. Here’s how to contribute.
-      </p>
-
-      <section class="space-y-6">
-        <h2 class="text-2xl font-semibold">How to submit a review</h2>
-        <ol class="list-decimal list-inside space-y-3 text-gray-700">
-          <li>Create an account or log in.</li>
-          <li>Go to <a routerLink="/reviews/new" class="text-blue-600 hover:underline">New Review</a>.</li>
-          <li>Fill in the book title, author, genre, and your review text.</li>
-          <li>Add a rating from 1 to 5 stars.</li>
-          <li>Submit. Reviews may be moderated before publication.</li>
-        </ol>
-      </section>
-
-      <section class="mt-8 space-y-4">
-        <h2 class="text-2xl font-semibold">Guidelines</h2>
-        <ul class="list-disc list-inside space-y-2 text-gray-700">
-          <li>Be respectful and avoid spoilers without warning.</li>
-          <li>Focus on the book: style, plot, characters, and your opinion.</li>
-          <li>Original content only; do not copy from elsewhere.</li>
-        </ul>
-      </section>
-
-      <section class="mt-8">
-        <h2 class="text-2xl font-semibold mb-4">Questions?</h2>
-        <p class="text-gray-700">
-          <a routerLink="/blog/contact" class="text-blue-600 hover:underline">Contact us</a> for any questions about contributing.
+      <div class="pinterest-panel mt-6 p-8">
+        <h1 class="text-4xl font-bold text-[var(--text-dark)]">Contribution Guide</h1>
+        <p class="mt-4 text-lg text-[var(--text-muted)]">
+          We welcome book reviews from all readers. Here is how to contribute in a clean and consistent way.
         </p>
-      </section>
+
+        <section class="mt-8 space-y-4">
+          <h2 class="text-2xl font-semibold text-[var(--text-dark)]">How to submit a review</h2>
+          <ol class="list-decimal list-inside space-y-3 text-[var(--text-muted)]">
+            <li>Create an account or log in.</li>
+            <li>
+              Go to
+              <a routerLink="/reviews/new" class="font-semibold text-[var(--accent-strong)] hover:underline">New Review</a>.
+            </li>
+            <li>Fill in the book title, author, genre, and your review text.</li>
+            <li>Add a rating from 1 to 5 stars.</li>
+            <li>Submit. Reviews may be moderated before publication.</li>
+          </ol>
+        </section>
+
+        <section class="mt-8 space-y-4">
+          <h2 class="text-2xl font-semibold text-[var(--text-dark)]">Guidelines</h2>
+          <ul class="list-disc list-inside space-y-2 text-[var(--text-muted)]">
+            <li>Be respectful and avoid spoilers without warning.</li>
+            <li>Focus on the book: style, plot, characters, and your opinion.</li>
+            <li>Original content only; do not copy from elsewhere.</li>
+          </ul>
+        </section>
+
+        <section class="mt-8">
+          <h2 class="text-2xl font-semibold text-[var(--text-dark)]">Questions?</h2>
+          <p class="mt-3 text-[var(--text-muted)]">
+            <a routerLink="/blog/contact" class="font-semibold text-[var(--accent-strong)] hover:underline">Contact us</a>
+            for any questions about contributing.
+          </p>
+        </section>
+      </div>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/app/features/reviews/pages/review-detail/review-detail.component.ts
+++ b/src/app/features/reviews/pages/review-detail/review-detail.component.ts
@@ -19,50 +19,57 @@ import { Subject, takeUntil } from 'rxjs';
   standalone: true,
   imports: [CommonModule, RouterLink, LoadingSpinnerComponent],
   template: `
-    <div class="container mx-auto px-4 py-8">
-      <a routerLink="/" class="text-blue-600 hover:text-blue-800 mb-4 inline-block">← Back to Reviews</a>
+    <div class="container mx-auto px-4 py-10">
+      <a routerLink="/" class="text-[var(--accent-strong)] hover:text-[var(--primary)] mb-4 inline-block font-semibold">
+        ← Back to Reviews
+      </a>
 
       <app-loading-spinner *ngIf="isLoading$ | async"></app-loading-spinner>
 
-      <div *ngIf="review$ | async as review" class="bg-white rounded-lg shadow-lg p-8">
+      <div *ngIf="review$ | async as review" class="pinterest-panel p-8">
         <div class="mb-6">
-          <h1 class="text-4xl font-bold mb-2">{{ review.title }}</h1>
-          <p class="text-lg text-gray-600">by {{ review.author }}</p>
+          <h1 class="text-4xl font-bold mb-2 text-[var(--primary)]">{{ review.title }}</h1>
+          <p class="text-lg text-[var(--text-muted)]">by {{ review.author }}</p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
           <div class="md:col-span-2">
             <div class="mb-6">
-              <h2 class="text-2xl font-semibold mb-4">{{ review.bookTitle }}</h2>
-              <p class="text-lg text-gray-600 mb-4">Book Author: {{ review.bookAuthor }}</p>
+              <h2 class="text-2xl font-semibold mb-4 text-[var(--primary)]">{{ review.bookTitle }}</h2>
+              <p class="text-lg text-[var(--text-muted)] mb-4">Book Author: {{ review.bookAuthor }}</p>
               <div class="flex items-center gap-4 mb-4">
                 <span class="text-3xl text-[var(--accent)]">★ {{ review.rating }}/5</span>
-                <span class="text-lg bg-blue-100 text-blue-800 px-3 py-1 rounded">{{ review.genre }}</span>
+                <span class="text-sm bg-[var(--surface-alt)] text-[var(--accent-strong)] px-4 py-1 rounded-full font-semibold">
+                  {{ review.genre }}
+                </span>
               </div>
             </div>
 
             <div class="prose max-w-none">
-              <p class="text-gray-700 whitespace-pre-wrap">{{ review.content }}</p>
+              <p class="text-[var(--text-dark)] whitespace-pre-wrap">{{ review.content }}</p>
             </div>
           </div>
 
-          <div class="bg-gray-50 p-6 rounded-lg h-fit">
+          <div class="bg-[var(--surface-alt)] border border-[var(--border-light)] p-6 rounded-2xl h-fit">
             <div class="mb-6">
               <img
                 *ngIf="review.imageUrl"
                 [src]="review.imageUrl"
                 [alt]="review.bookTitle"
-                class="w-full rounded mb-4"
+                class="w-full rounded-2xl mb-4 border border-[var(--border-light)]"
               />
-              <div *ngIf="!review.imageUrl" class="w-full h-64 bg-gray-300 rounded mb-4 flex items-center justify-center">
-                <span class="text-gray-500">No image available</span>
+              <div
+                *ngIf="!review.imageUrl"
+                class="w-full h-64 bg-white rounded-2xl mb-4 flex items-center justify-center border border-[var(--border-light)]"
+              >
+                <span class="text-[var(--text-muted)]">No image available</span>
               </div>
             </div>
 
             <div class="space-y-3 text-sm">
               <div>
                 <span class="font-semibold">Genre:</span>
-                <span class="text-gray-600">{{ review.genre }}</span>
+                <span class="text-[var(--text-muted)]">{{ review.genre }}</span>
               </div>
               <div>
                 <span class="font-semibold">Rating:</span>
@@ -70,11 +77,11 @@ import { Subject, takeUntil } from 'rxjs';
               </div>
               <div>
                 <span class="font-semibold">Published:</span>
-                <span class="text-gray-600">{{ review.publishedAt | date: 'short' }}</span>
+                <span class="text-[var(--text-muted)]">{{ review.publishedAt | date: 'short' }}</span>
               </div>
               <div>
                 <span class="font-semibold">Last Updated:</span>
-                <span class="text-gray-600">{{ review.updatedAt | date: 'short' }}</span>
+                <span class="text-[var(--text-muted)]">{{ review.updatedAt | date: 'short' }}</span>
               </div>
             </div>
           </div>

--- a/src/app/features/reviews/pages/review-detail/review-detail.component.ts
+++ b/src/app/features/reviews/pages/review-detail/review-detail.component.ts
@@ -28,14 +28,14 @@ import { Subject, takeUntil } from 'rxjs';
 
       <div *ngIf="review$ | async as review" class="pinterest-panel p-8">
         <div class="mb-6">
-          <h1 class="text-4xl font-bold mb-2 text-[var(--primary)]">{{ review.title }}</h1>
+          <h1 class="text-4xl font-semibold tracking-tight mb-2 text-[var(--primary)]">{{ review.title }}</h1>
           <p class="text-lg text-[var(--text-muted)]">by {{ review.author }}</p>
         </div>
 
         <div class="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
           <div class="md:col-span-2">
             <div class="mb-6">
-              <h2 class="text-2xl font-semibold mb-4 text-[var(--primary)]">{{ review.bookTitle }}</h2>
+              <h2 class="text-2xl font-semibold tracking-tight mb-4 text-[var(--primary)]">{{ review.bookTitle }}</h2>
               <p class="text-lg text-[var(--text-muted)] mb-4">Book Author: {{ review.bookAuthor }}</p>
               <div class="flex items-center gap-4 mb-4">
                 <span class="text-3xl text-[var(--accent)]">★ {{ review.rating }}/5</span>

--- a/src/app/features/reviews/pages/review-form/review-form.component.ts
+++ b/src/app/features/reviews/pages/review-form/review-form.component.ts
@@ -22,22 +22,22 @@ import { Subject, takeUntil } from 'rxjs';
     LoadingSpinnerComponent,
   ],
   template: `
-    <div class="container mx-auto px-4 py-8">
-      <h1 class="text-4xl font-bold mb-8">
+    <div class="container mx-auto px-4 py-10">
+      <h1 class="text-4xl md:text-5xl font-bold mb-8 text-[var(--primary)]">
         {{ isEditMode ? 'Edit Review' : 'Create New Review' }}
       </h1>
 
-      <div class="max-w-2xl bg-white rounded-lg shadow-lg p-8">
+      <div class="max-w-3xl pinterest-panel p-8 md:p-10">
         <form *ngIf="reviewForm" [formGroup]="reviewForm" (ngSubmit)="onSubmit()" class="space-y-6">
           <!-- Title -->
           <div>
-            <label for="title" class="block text-sm font-semibold mb-2">Review Title *</label>
+            <label for="title" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Review Title *</label>
             <input
               id="title"
               type="text"
               formControlName="title"
               placeholder="Enter review title"
-              class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
               [attr.aria-label]="'Review Title'"
               [attr.aria-invalid]="isFieldInvalid('title')"
             />
@@ -46,13 +46,13 @@ import { Subject, takeUntil } from 'rxjs';
 
           <!-- Book Title -->
           <div>
-            <label for="bookTitle" class="block text-sm font-semibold mb-2">Book Title *</label>
+            <label for="bookTitle" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Book Title *</label>
             <input
               id="bookTitle"
               type="text"
               formControlName="bookTitle"
               placeholder="Enter book title"
-              class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
               [attr.aria-label]="'Book Title'"
               [attr.aria-invalid]="isFieldInvalid('bookTitle')"
             />
@@ -61,13 +61,13 @@ import { Subject, takeUntil } from 'rxjs';
 
           <!-- Book Author -->
           <div>
-            <label for="bookAuthor" class="block text-sm font-semibold mb-2">Book Author *</label>
+            <label for="bookAuthor" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Book Author *</label>
             <input
               id="bookAuthor"
               type="text"
               formControlName="bookAuthor"
               placeholder="Enter book author"
-              class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
               [attr.aria-label]="'Book Author'"
               [attr.aria-invalid]="isFieldInvalid('bookAuthor')"
             />
@@ -76,11 +76,11 @@ import { Subject, takeUntil } from 'rxjs';
 
           <!-- Genre -->
           <div>
-            <label for="genre" class="block text-sm font-semibold mb-2">Genre *</label>
+            <label for="genre" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Genre *</label>
             <select
               id="genre"
               formControlName="genre"
-              class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
               [attr.aria-label]="'Genre'"
               [attr.aria-invalid]="isFieldInvalid('genre')"
             >
@@ -101,7 +101,7 @@ import { Subject, takeUntil } from 'rxjs';
 
           <!-- Rating -->
           <div>
-            <label for="rating" class="block text-sm font-semibold mb-2">Rating (1-5) *</label>
+            <label for="rating" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Rating (1-5) *</label>
             <input
               id="rating"
               type="number"
@@ -109,7 +109,7 @@ import { Subject, takeUntil } from 'rxjs';
               min="1"
               max="5"
               placeholder="Enter rating"
-              class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
               [attr.aria-label]="'Rating'"
               [attr.aria-invalid]="isFieldInvalid('rating')"
             />
@@ -120,34 +120,34 @@ import { Subject, takeUntil } from 'rxjs';
 
           <!-- Description (Short Summary) -->
           <div>
-            <label for="description" class="block text-sm font-semibold mb-2">Description *</label>
+            <label for="description" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Description *</label>
             <textarea
               id="description"
               formControlName="description"
               placeholder="Enter a short description (max 300 characters)"
               rows="3"
               maxlength="300"
-              class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
               [attr.aria-label]="'Description'"
               [attr.aria-invalid]="isFieldInvalid('description')"
             ></textarea>
             <p *ngIf="isFieldInvalid('description')" class="text-red-600 text-sm mt-1">
               Description is required
             </p>
-            <p class="text-gray-500 text-xs mt-1">
+            <p class="text-[var(--text-muted)] text-xs mt-1">
               {{ reviewForm.get('description')?.value?.length || 0 }}/300 characters
             </p>
           </div>
 
           <!-- Content (Full Review) -->
           <div>
-            <label for="content" class="block text-sm font-semibold mb-2">Full Review *</label>
+            <label for="content" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Full Review *</label>
             <textarea
               id="content"
               formControlName="content"
               placeholder="Enter the full review content"
               rows="10"
-              class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] font-mono text-sm"
+              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] text-sm"
               [attr.aria-label]="'Review Content'"
               [attr.aria-invalid]="isFieldInvalid('content')"
             ></textarea>
@@ -156,16 +156,16 @@ import { Subject, takeUntil } from 'rxjs';
 
           <!-- Image URL -->
           <div>
-            <label for="imageUrl" class="block text-sm font-semibold mb-2">Book Cover Image URL</label>
+            <label for="imageUrl" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Book Cover Image URL</label>
             <input
               id="imageUrl"
               type="url"
               formControlName="imageUrl"
               placeholder="Enter image URL (optional)"
-              class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
               [attr.aria-label]="'Image URL'"
             />
-            <p class="text-gray-500 text-xs mt-1">Optional: Paste a URL to a book cover image</p>
+            <p class="text-[var(--text-muted)] text-xs mt-1">Optional: Paste a URL to a book cover image</p>
           </div>
 
           <!-- Published Status -->
@@ -177,7 +177,7 @@ import { Subject, takeUntil } from 'rxjs';
               class="w-4 h-4 cursor-pointer"
               [attr.aria-label]="'Publish this review'"
             />
-            <label for="isPublished" class="text-sm font-semibold cursor-pointer">
+            <label for="isPublished" class="text-sm font-semibold cursor-pointer text-[var(--primary)]">
               Publish this review immediately
             </label>
           </div>

--- a/src/app/features/reviews/pages/review-list/review-list.component.ts
+++ b/src/app/features/reviews/pages/review-list/review-list.component.ts
@@ -34,7 +34,7 @@ import { Subject, takeUntil } from 'rxjs';
   template: `
     <div class="page-container">
       <div class="mb-8">
-        <h1 class="text-4xl font-bold mb-2 text-[var(--primary)]">Book Reviews</h1>
+        <h1 class="text-4xl font-bold mb-2 text-[var(--primary)] luxe-title">Book Reviews</h1>
         <p class="text-[var(--text-muted)]">
           Explore stylish, curated reviews in a clean Pinterest-inspired layout.
         </p>
@@ -42,7 +42,7 @@ import { Subject, takeUntil } from 'rxjs';
 
       <!-- Filters -->
       <div class="mb-8 pinterest-panel p-6">
-        <h2 class="text-xl font-semibold mb-4 text-[var(--primary)]">Filters</h2>
+        <h2 class="text-xl font-semibold mb-4 text-[var(--primary)] luxe-title">Filters</h2>
         <div class="grid grid-cols-1 md:grid-cols-5 gap-4">
           <input
             type="text"

--- a/src/app/features/reviews/pages/review-list/review-list.component.ts
+++ b/src/app/features/reviews/pages/review-list/review-list.component.ts
@@ -32,25 +32,30 @@ import { Subject, takeUntil } from 'rxjs';
     PaginationComponent,
   ],
   template: `
-    <div class="container mx-auto px-4 py-8">
-      <h1 class="text-4xl font-bold mb-8">Book Reviews</h1>
+    <div class="page-container">
+      <div class="mb-8">
+        <h1 class="text-4xl font-bold mb-2 text-[var(--primary)]">Book Reviews</h1>
+        <p class="text-[var(--text-muted)]">
+          Explore stylish, curated reviews in a clean Pinterest-inspired layout.
+        </p>
+      </div>
 
       <!-- Filters -->
-      <div class="mb-8 bg-white p-6 rounded-lg shadow">
-        <h2 class="text-xl font-semibold mb-4">Filters</h2>
+      <div class="mb-8 pinterest-panel p-6">
+        <h2 class="text-xl font-semibold mb-4 text-[var(--primary)]">Filters</h2>
         <div class="grid grid-cols-1 md:grid-cols-5 gap-4">
           <input
             type="text"
             placeholder="Search reviews..."
             [(ngModel)]="searchQuery"
             (change)="onFilterChange()"
-            class="border rounded px-3 py-2"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white"
             aria-label="Search reviews"
           />
           <select
             [(ngModel)]="selectedGenre"
             (change)="onFilterChange()"
-            class="border rounded px-3 py-2"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white"
             aria-label="Filter by genre"
           >
             <option value="">All Genres</option>
@@ -62,7 +67,7 @@ import { Subject, takeUntil } from 'rxjs';
           <select
             [(ngModel)]="selectedRating"
             (change)="onFilterChange()"
-            class="border rounded px-3 py-2"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white"
             aria-label="Filter by rating"
           >
             <option value="">All Ratings</option>
@@ -73,7 +78,7 @@ import { Subject, takeUntil } from 'rxjs';
           <select
             [(ngModel)]="selectedSort"
             (change)="onFilterChange()"
-            class="border rounded px-3 py-2"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white"
             aria-label="Sort reviews"
           >
             <option value="">Sort by</option>
@@ -84,7 +89,7 @@ import { Subject, takeUntil } from 'rxjs';
           </select>
           <button
             (click)="resetFilters()"
-            class="bg-slate-500 text-white rounded px-3 py-2 hover:bg-slate-600"
+            class="bg-white text-[var(--primary)] border border-[var(--border-light)] rounded-full px-3 py-2 hover:bg-[var(--surface-alt)]"
           >
             Reset
           </button>
@@ -97,28 +102,32 @@ import { Subject, takeUntil } from 'rxjs';
       <!-- Reviews List -->
       <div
         *ngIf="(isLoading$ | async) === false"
-        class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6"
+        class="columns-1 md:columns-2 xl:columns-3 gap-6 space-y-6"
       >
         <app-card
           *ngFor="let review of reviews$ | async; trackBy: trackByReviewId"
           [hoverable]="true"
+          class="break-inside-avoid block mb-6"
           (click)="goToReview(review.id)"
         >
-          <h3 class="text-lg font-semibold mb-2">{{ review.title }}</h3>
-          <p class="text-sm text-gray-600 mb-2">by {{ review.author }}</p>
+          <h3 class="text-xl font-semibold mb-2 text-[var(--primary)]">{{ review.title }}</h3>
+          <p class="text-sm text-[var(--text-muted)] mb-3">by {{ review.author }}</p>
           <p class="text-sm mb-2">
-            <strong>Book:</strong> {{ review.bookTitle }} by {{ review.bookAuthor }}
+            <strong class="text-[var(--primary)]">Book:</strong> {{ review.bookTitle }} by {{ review.bookAuthor }}
           </p>
           <p class="text-sm mb-2">
-            <strong>Genre:</strong> {{ review.genre }}
+            <strong class="text-[var(--primary)]">Genre:</strong>
+            <span class="inline-block px-2 py-1 rounded-full bg-[var(--surface-alt)] text-[var(--accent-strong)]">
+              {{ review.genre }}
+            </span>
           </p>
           <div class="flex items-center gap-2 mb-3">
-            <span class="text-[var(--accent)]">★ {{ review.rating }}/5</span>
+            <span class="text-[var(--accent-strong)] font-semibold">★ {{ review.rating }}/5</span>
           </div>
-          <p class="text-sm text-gray-700 line-clamp-3 mb-4">{{ review.description }}</p>
+          <p class="text-sm text-[var(--text-dark)] line-clamp-3 mb-4">{{ review.description }}</p>
           <a
             [routerLink]="['/reviews', review.id]"
-            class="text-blue-600 hover:text-blue-800 font-semibold"
+            class="text-[var(--accent-strong)] hover:text-[var(--primary)] font-semibold"
           >
             Read Full Review →
           </a>
@@ -127,7 +136,7 @@ import { Subject, takeUntil } from 'rxjs';
 
       <!-- No Results -->
       <div *ngIf="(reviews$ | async)?.length === 0 && (isLoading$ | async) === false" class="text-center py-12">
-        <p class="text-xl text-gray-500">No reviews found. Try adjusting your filters.</p>
+        <p class="text-xl text-[var(--text-muted)]">No reviews found. Try adjusting your filters.</p>
       </div>
 
       <!-- Pagination -->

--- a/src/app/shared/components/button/button.component.ts
+++ b/src/app/shared/components/button/button.component.ts
@@ -40,7 +40,7 @@ export class ButtonComponent {
 
   getClasses(): string {
     const baseClasses =
-      'rounded-full font-semibold transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm hover:shadow-md';
+      'rounded-full font-semibold transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm hover:shadow-md disabled:hover:shadow-none';
 
     const variantClasses: Record<ButtonVariant, string> = {
       primary: 'bg-[var(--primary)] text-[var(--text-light)] hover:brightness-110',

--- a/src/app/shared/components/button/button.component.ts
+++ b/src/app/shared/components/button/button.component.ts
@@ -40,13 +40,13 @@ export class ButtonComponent {
 
   getClasses(): string {
     const baseClasses =
-      'rounded font-semibold transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed';
+      'rounded-full font-semibold transition-all duration-200 disabled:opacity-50 disabled:cursor-not-allowed shadow-sm hover:shadow-md';
 
     const variantClasses: Record<ButtonVariant, string> = {
-      primary: 'bg-[var(--accent)] text-[var(--primary)] hover:brightness-95',
-      secondary: 'bg-slate-700 text-white hover:bg-slate-600',
-      danger: 'bg-red-600 text-white hover:bg-red-700',
-      ghost: 'bg-transparent border border-current text-current hover:bg-slate-100',
+      primary: 'bg-[var(--primary)] text-[var(--text-light)] hover:brightness-110',
+      secondary: 'bg-[var(--secondary)] text-white hover:brightness-105',
+      danger: 'bg-rose-600 text-white hover:bg-rose-700',
+      ghost: 'bg-white/80 border border-[var(--border-light)] text-[var(--text-dark)] hover:bg-[var(--surface-alt)]',
     };
 
     const sizeClasses: Record<ButtonSize, string> = {

--- a/src/app/shared/components/card/card.component.ts
+++ b/src/app/shared/components/card/card.component.ts
@@ -22,10 +22,9 @@ export class CardComponent {
   @Input() hoverable: boolean = false;
 
   getClasses(): string {
-    let classes = 'bg-white/95 border border-[var(--border-light)] rounded-2xl shadow-[0_14px_35px_-24px_rgba(122,54,95,0.65)] p-5';
+    let classes = 'bg-white/95 border border-[var(--border-light)] rounded-2xl shadow-[0_12px_24px_-24px_rgba(122,54,95,0.55)] p-5';
     if (this.hoverable) {
-      classes +=
-        ' hover:-translate-y-1 hover:shadow-[0_18px_40px_-22px_rgba(122,54,95,0.75)] transition-all duration-200 cursor-pointer';
+      classes += ' hover:shadow-[0_15px_28px_-24px_rgba(122,54,95,0.62)] transition-shadow duration-200 cursor-pointer';
     }
     return classes;
   }

--- a/src/app/shared/components/card/card.component.ts
+++ b/src/app/shared/components/card/card.component.ts
@@ -22,9 +22,10 @@ export class CardComponent {
   @Input() hoverable: boolean = false;
 
   getClasses(): string {
-    let classes = 'bg-white rounded-lg shadow p-4';
+    let classes = 'bg-white/95 border border-[var(--border-light)] rounded-2xl shadow-[0_14px_35px_-24px_rgba(122,54,95,0.65)] p-5';
     if (this.hoverable) {
-      classes += ' hover:shadow-lg transition-shadow duration-200 cursor-pointer';
+      classes +=
+        ' hover:-translate-y-1 hover:shadow-[0_18px_40px_-22px_rgba(122,54,95,0.75)] transition-all duration-200 cursor-pointer';
     }
     return classes;
   }

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -11,7 +11,7 @@ import { SiteConfigService } from '@core/services/site-config.service';
   standalone: true,
   imports: [RouterLink],
   template: `
-    <footer class="mt-16 border-t border-[var(--border-light)] bg-[var(--surface-alt)]/80 backdrop-blur-sm" role="contentinfo">
+    <footer class="mt-16 border-t border-[var(--border-light)] bg-[color:var(--surface-alt)] backdrop-blur-sm" role="contentinfo">
       <div class="container mx-auto px-4 py-12 text-[var(--text-dark)]">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
           <div>
@@ -26,21 +26,21 @@ import { SiteConfigService } from '@core/services/site-config.service';
             <h3 class="font-bold mb-4 text-[var(--primary)]">Resources</h3>
             <ul class="space-y-2">
               <li><a routerLink="/blog" class="hover:text-[var(--primary)] transition">Blog</a></li>
-              <li><a href="#" class="hover:text-[var(--primary)] transition">FAQ</a></li>
+              <li><span class="text-[var(--text-muted)] cursor-not-allowed" aria-disabled="true">FAQ</span></li>
             </ul>
           </div>
           <div>
             <h3 class="font-bold mb-4 text-[var(--primary)]">Legal</h3>
             <ul class="space-y-2">
-              <li><a href="#" class="hover:text-[var(--primary)] transition">Privacy Policy</a></li>
-              <li><a href="#" class="hover:text-[var(--primary)] transition">Terms of Service</a></li>
+              <li><span class="text-[var(--text-muted)] cursor-not-allowed" aria-disabled="true">Privacy Policy</span></li>
+              <li><span class="text-[var(--text-muted)] cursor-not-allowed" aria-disabled="true">Terms of Service</span></li>
             </ul>
           </div>
           <div>
             <h3 class="font-bold mb-4 text-[var(--primary)]">Follow Us</h3>
             <ul class="space-y-2">
-              <li><a href="#" class="hover:text-[var(--primary)] transition">Twitter</a></li>
-              <li><a href="#" class="hover:text-[var(--primary)] transition">Facebook</a></li>
+              <li><span class="text-[var(--text-muted)] cursor-not-allowed" aria-disabled="true">Twitter</span></li>
+              <li><span class="text-[var(--text-muted)] cursor-not-allowed" aria-disabled="true">Facebook</span></li>
             </ul>
           </div>
         </div>

--- a/src/app/shared/components/footer/footer.component.ts
+++ b/src/app/shared/components/footer/footer.component.ts
@@ -11,40 +11,40 @@ import { SiteConfigService } from '@core/services/site-config.service';
   standalone: true,
   imports: [RouterLink],
   template: `
-    <footer class="bg-[var(--primary)] text-white mt-16 border-t border-white/15" role="contentinfo">
-      <div class="container mx-auto px-4 py-12">
+    <footer class="mt-16 border-t border-[var(--border-light)] bg-[var(--surface-alt)]/80 backdrop-blur-sm" role="contentinfo">
+      <div class="container mx-auto px-4 py-12 text-[var(--text-dark)]">
         <div class="grid grid-cols-1 md:grid-cols-4 gap-8 mb-8">
           <div>
-            <h3 class="font-bold mb-4">About</h3>
+            <h3 class="font-bold mb-4 text-[var(--primary)]">About</h3>
             <ul class="space-y-2">
-              <li><a routerLink="/blog/about" class="hover:text-[var(--accent)] transition">About Us</a></li>
-              <li><a routerLink="/blog/contact" class="hover:text-[var(--accent)] transition">Contact</a></li>
-              <li><a routerLink="/blog/contribute" class="hover:text-[var(--accent)] transition">Contribute</a></li>
+              <li><a routerLink="/blog/about" class="hover:text-[var(--primary)] transition">About Us</a></li>
+              <li><a routerLink="/blog/contact" class="hover:text-[var(--primary)] transition">Contact</a></li>
+              <li><a routerLink="/blog/contribute" class="hover:text-[var(--primary)] transition">Contribute</a></li>
             </ul>
           </div>
           <div>
-            <h3 class="font-bold mb-4">Resources</h3>
+            <h3 class="font-bold mb-4 text-[var(--primary)]">Resources</h3>
             <ul class="space-y-2">
-              <li><a routerLink="/blog" class="hover:text-[var(--accent)] transition">Blog</a></li>
-              <li><a href="#" class="hover:text-[var(--accent)] transition">FAQ</a></li>
+              <li><a routerLink="/blog" class="hover:text-[var(--primary)] transition">Blog</a></li>
+              <li><a href="#" class="hover:text-[var(--primary)] transition">FAQ</a></li>
             </ul>
           </div>
           <div>
-            <h3 class="font-bold mb-4">Legal</h3>
+            <h3 class="font-bold mb-4 text-[var(--primary)]">Legal</h3>
             <ul class="space-y-2">
-              <li><a href="#" class="hover:text-[var(--accent)] transition">Privacy Policy</a></li>
-              <li><a href="#" class="hover:text-[var(--accent)] transition">Terms of Service</a></li>
+              <li><a href="#" class="hover:text-[var(--primary)] transition">Privacy Policy</a></li>
+              <li><a href="#" class="hover:text-[var(--primary)] transition">Terms of Service</a></li>
             </ul>
           </div>
           <div>
-            <h3 class="font-bold mb-4">Follow Us</h3>
+            <h3 class="font-bold mb-4 text-[var(--primary)]">Follow Us</h3>
             <ul class="space-y-2">
-              <li><a href="#" class="hover:text-[var(--accent)] transition">Twitter</a></li>
-              <li><a href="#" class="hover:text-[var(--accent)] transition">Facebook</a></li>
+              <li><a href="#" class="hover:text-[var(--primary)] transition">Twitter</a></li>
+              <li><a href="#" class="hover:text-[var(--primary)] transition">Facebook</a></li>
             </ul>
           </div>
         </div>
-        <div class="border-t border-white/15 pt-8 text-center text-sm text-gray-400">
+        <div class="border-t border-[var(--border-light)] pt-8 text-center text-sm text-[var(--text-muted)]">
           <p>&copy; {{ site.config().copyrightYear }} {{ site.config().siteName }}. All rights reserved.</p>
         </div>
       </div>

--- a/src/app/shared/components/form-input/form-input.component.ts
+++ b/src/app/shared/components/form-input/form-input.component.ts
@@ -27,7 +27,7 @@ import { ReactiveFormsModule } from '@angular/forms';
         (input)="onInput($event)"
         [attr.aria-invalid]="isInvalid"
         [attr.aria-describedby]="errorId"
-        class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+        class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2.5 bg-white/90 focus:outline-none focus:ring-2 focus:ring-[var(--secondary)]"
         [class.border-red-600]="isInvalid"
       />
       <p *ngIf="isInvalid && errorMessage" [id]="errorId" class="text-red-600 text-sm mt-1">

--- a/src/app/shared/components/form-select/form-select.component.ts
+++ b/src/app/shared/components/form-select/form-select.component.ts
@@ -18,7 +18,7 @@ export interface SelectOption {
     <div class="mb-4">
       <label
         [for]="id"
-        class="block text-sm font-semibold mb-2"
+        class="block text-sm font-semibold mb-2 text-[var(--text-dark)]"
         [attr.aria-label]="label"
       >
         {{ label }}
@@ -30,7 +30,7 @@ export interface SelectOption {
         (change)="onChange($event)"
         [attr.aria-invalid]="isInvalid"
         [attr.aria-describedby]="errorId"
-        class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+        class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white focus:outline-none focus:ring-2 focus:ring-[var(--secondary)]"
         [class.border-red-600]="isInvalid"
       >
         <option value="">{{ placeholder }}</option>

--- a/src/app/shared/components/form-textarea/form-textarea.component.ts
+++ b/src/app/shared/components/form-textarea/form-textarea.component.ts
@@ -27,7 +27,7 @@ import { ReactiveFormsModule } from '@angular/forms';
         (input)="onInput($event)"
         [attr.aria-invalid]="isInvalid"
         [attr.aria-describedby]="errorId"
-        class="w-full border border-[#f0cfdf] bg-white rounded-2xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#f3b9d4] focus:border-[#d56fa1]"
+        class="w-full border border-[var(--border-light)] bg-white rounded-2xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] focus:border-[var(--secondary)]"
         [class.border-red-600]="isInvalid"
       ></textarea>
       <p *ngIf="isInvalid && errorMessage" [id]="errorId" class="text-red-600 text-sm mt-1">

--- a/src/app/shared/components/form-textarea/form-textarea.component.ts
+++ b/src/app/shared/components/form-textarea/form-textarea.component.ts
@@ -27,7 +27,7 @@ import { ReactiveFormsModule } from '@angular/forms';
         (input)="onInput($event)"
         [attr.aria-invalid]="isInvalid"
         [attr.aria-describedby]="errorId"
-        class="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+        class="w-full border border-[#f0cfdf] bg-white rounded-2xl px-4 py-3 focus:outline-none focus:ring-2 focus:ring-[#f3b9d4] focus:border-[#d56fa1]"
         [class.border-red-600]="isInvalid"
       ></textarea>
       <p *ngIf="isInvalid && errorMessage" [id]="errorId" class="text-red-600 text-sm mt-1">

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -25,7 +25,7 @@ import { Subject } from 'rxjs';
         <div class="flex items-center gap-8">
           <a
             routerLink="/"
-            class="text-2xl font-bold text-[var(--primary)]"
+            class="text-2xl font-semibold text-[var(--primary)] luxe-title tracking-[0.01em]"
             [attr.aria-label]="site.config().siteNameShort + ' home'"
             >📚 {{ site.config().siteNameShort }}</a
           >

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -16,32 +16,51 @@ import { Subject } from 'rxjs';
   standalone: true,
   imports: [CommonModule, RouterLink],
   template: `
-    <header class="bg-[var(--primary)] text-white shadow-lg" role="banner">
+    <header class="sticky top-0 z-40 border-b border-[var(--border-light)] bg-[#fff9fc]/85 backdrop-blur-md" role="banner">
       <a href="#main-content" class="skip-link">Skip to main content</a>
-      <nav class="container mx-auto px-4 py-4 flex items-center justify-between" aria-label="Main navigation">
+      <nav
+        class="container mx-auto my-3 flex items-center justify-between gap-4 rounded-full border border-[var(--border-light)] bg-white/95 px-5 py-3 shadow-[0_10px_24px_-20px_rgba(122,54,95,0.8)]"
+        aria-label="Main navigation"
+      >
         <div class="flex items-center gap-8">
           <a
             routerLink="/"
-            class="text-2xl font-bold"
+            class="text-2xl font-bold text-[var(--primary)]"
             [attr.aria-label]="site.config().siteNameShort + ' home'"
             >📚 {{ site.config().siteNameShort }}</a
           >
           <ul class="hidden md:flex gap-6" role="menubar">
-            <li role="none"><a routerLink="/" class="hover:text-[var(--accent)] transition" role="menuitem">Home</a></li>
-            <li role="none"><a routerLink="/blog" class="hover:text-[var(--accent)] transition" role="menuitem">Blog</a></li>
+            <li role="none">
+              <a routerLink="/" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] transition" role="menuitem"
+                >Home</a
+              >
+            </li>
+            <li role="none">
+              <a
+                routerLink="/blog"
+                class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] transition"
+                role="menuitem"
+                >Blog</a
+              >
+            </li>
             <li *ngIf="(currentUser$ | async)?.role === 'admin'" role="none">
-              <a routerLink="/admin" class="hover:text-[var(--accent)] transition" role="menuitem">Admin</a>
+              <a
+                routerLink="/admin"
+                class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] transition"
+                role="menuitem"
+                >Admin</a
+              >
             </li>
           </ul>
         </div>
         <div class="flex items-center gap-4">
-          <div *ngIf="currentUser$ | async as user" class="text-sm">
+          <div *ngIf="currentUser$ | async as user" class="text-sm text-[var(--text-muted)]">
             Welcome, {{ user.name || user.email }}
           </div>
           <button
             *ngIf="isAuthenticated$ | async"
             routerLink="/reviews/new"
-            class="bg-[var(--secondary)] text-white px-4 py-2 rounded font-semibold hover:brightness-90 transition"
+            class="bg-[var(--secondary)] text-white px-4 py-2 rounded-full font-semibold hover:brightness-95 transition"
             aria-label="Create new review"
           >
             + New Review
@@ -49,7 +68,7 @@ import { Subject } from 'rxjs';
           <button
             *ngIf="(isAuthenticated$ | async) === false"
             routerLink="/login"
-            class="bg-[var(--accent)] text-[var(--primary)] px-4 py-2 rounded font-semibold hover:brightness-95 transition"
+            class="bg-[var(--accent)] text-[var(--primary)] px-4 py-2 rounded-full font-semibold hover:brightness-95 transition"
             aria-label="Login"
           >
             Login
@@ -57,7 +76,7 @@ import { Subject } from 'rxjs';
           <button
             *ngIf="isAuthenticated$ | async"
             (click)="logout()"
-            class="bg-red-600 px-4 py-2 rounded font-semibold hover:bg-red-700 transition"
+            class="bg-[#bc4a79] px-4 py-2 rounded-full font-semibold text-white hover:brightness-95 transition"
             aria-label="Logout"
           >
             Logout

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -27,7 +27,7 @@ import { Subject } from 'rxjs';
             routerLink="/"
             class="text-2xl font-semibold text-[var(--primary)] luxe-title tracking-[0.01em]"
             [attr.aria-label]="site.config().siteNameShort + ' home'"
-            >📚 {{ site.config().siteNameShort }}</a
+            ><span aria-hidden="true">📚</span> {{ site.config().siteNameShort }}</a
           >
           <ul class="hidden md:flex gap-6" role="menubar">
             <li role="none">

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -100,13 +100,14 @@ export class NotificationComponent {
    * Get notification classes based on type
    */
   getNotificationClasses(type: string): string {
-    const baseClasses = 'p-4 rounded-lg shadow-lg animate-slideIn text-white flex gap-3';
+    const baseClasses =
+      'p-4 rounded-2xl border shadow-lg animate-slideIn text-white flex gap-3 backdrop-blur-sm';
 
     const typeClasses: Record<string, string> = {
-      success: 'bg-[var(--secondary)]',
-      error: 'bg-red-600',
-      warning: 'bg-yellow-600',
-      info: 'bg-blue-600',
+      success: 'bg-[var(--secondary)] border-[#f4c6dd] text-[#3d2031]',
+      error: 'bg-[#d64f78] border-[#e484a2] text-white',
+      warning: 'bg-[#e98eb5] border-[#f3b9d4] text-[#3d2031]',
+      info: 'bg-[var(--primary)] border-[#a85a84] text-[#fff8fc]',
     };
 
     return `${baseClasses} ${typeClasses[type] || typeClasses['info']}`;

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -101,7 +101,7 @@ export class NotificationComponent {
    */
   getNotificationClasses(type: string): string {
     const baseClasses =
-      'p-4 rounded-2xl border shadow-lg animate-slideIn text-white flex gap-3 backdrop-blur-sm';
+      'p-4 rounded-2xl border shadow-lg flex gap-3 backdrop-blur-sm';
 
     const typeClasses: Record<string, string> = {
       success: 'bg-[var(--secondary)] border-[#f4c6dd] text-[#3d2031]',

--- a/src/app/shared/components/pagination/pagination.component.ts
+++ b/src/app/shared/components/pagination/pagination.component.ts
@@ -15,9 +15,9 @@ export interface PaginationEvent {
   standalone: true,
   imports: [CommonModule],
   template: `
-    <div class="flex flex-col sm:flex-row items-center justify-between gap-4 py-6">
+    <div class="pinterest-panel flex flex-col gap-4 p-5 sm:flex-row sm:items-center sm:justify-between">
       <!-- Info -->
-      <div class="text-sm text-gray-600">
+      <div class="text-sm text-[var(--text-muted)]">
         Showing
         <span class="font-semibold">{{ startIndex }}</span>
         to
@@ -33,7 +33,7 @@ export interface PaginationEvent {
         <button
           (click)="onPrevious()"
           [disabled]="currentPage === 1"
-          class="px-3 py-2 rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          class="rounded-full border border-[var(--border-light)] px-3 py-2 transition hover:bg-[var(--surface-alt)] disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Previous page"
         >
           ← Previous
@@ -44,10 +44,10 @@ export interface PaginationEvent {
           <button
             *ngFor="let pageNum of pageNumbers"
             (click)="onPageChange(pageNum)"
-            class="px-3 py-2 rounded border border-gray-300 transition"
+            class="rounded-full border border-[var(--border-light)] px-3 py-2 transition"
             [ngClass]="{
-              'bg-[var(--accent)] text-[var(--primary)] font-semibold': pageNum === currentPage,
-              'hover:bg-gray-100': pageNum !== currentPage
+              'bg-[var(--secondary)] text-white font-semibold border-[var(--secondary)]': pageNum === currentPage,
+              'hover:bg-[var(--surface-alt)]': pageNum !== currentPage
             }"
             [attr.aria-label]="'Go to page ' + pageNum"
           >
@@ -64,7 +64,7 @@ export interface PaginationEvent {
         <button
           (click)="onNext()"
           [disabled]="currentPage === totalPages"
-          class="px-3 py-2 rounded border border-gray-300 hover:bg-gray-100 disabled:opacity-50 disabled:cursor-not-allowed transition"
+          class="rounded-full border border-[var(--border-light)] px-3 py-2 transition hover:bg-[var(--surface-alt)] disabled:cursor-not-allowed disabled:opacity-50"
           aria-label="Next page"
         >
           Next →
@@ -73,12 +73,12 @@ export interface PaginationEvent {
 
       <!-- Items Per Page -->
       <div class="flex items-center gap-2">
-        <label for="itemsPerPage" class="text-sm">Items per page:</label>
+        <label for="itemsPerPage" class="text-sm text-[var(--text-muted)]">Items per page:</label>
         <select
           id="itemsPerPage"
           [value]="limit"
           (change)="onLimitChange($event)"
-          class="border rounded px-2 py-1"
+          class="rounded-full border border-[var(--border-light)] bg-white px-3 py-1"
           aria-label="Items per page"
         >
           <option value="5">5</option>

--- a/src/index.html
+++ b/src/index.html
@@ -5,12 +5,6 @@
   <title>Book Review Blog</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-  <link
-    href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Inter:wght@400;500;600&display=swap"
-    rel="stylesheet"
-  >
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>

--- a/src/index.html
+++ b/src/index.html
@@ -5,6 +5,12 @@
   <title>Book Review Blog</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@500;600;700&family=Inter:wght@400;500;600&display=swap"
+    rel="stylesheet"
+  >
   <link rel="icon" type="image/x-icon" href="favicon.ico">
 </head>
 <body>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -15,6 +15,8 @@
   --text-light: #fff8fc;
   --text-muted: #8f667c;
   --border-light: #f0cfdf;
+  --font-sans: "Inter", "Avenir Next", "Avenir", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-luxe: "Cormorant Garamond", "Times New Roman", Georgia, serif;
 }
 
 /* Accessibility: skip link (hidden until focused) */
@@ -55,7 +57,7 @@
 
 html, body {
   height: 100%;
-  font-family: "Avenir Next", "Avenir", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  font-family: var(--font-sans);
   color: var(--text-dark);
   background-color: var(--surface);
   background-image: radial-gradient(circle at 15% 20%, #ffe0ee 0%, transparent 32%),
@@ -66,13 +68,16 @@ html, body {
 body {
   margin: 0;
   font-size: 1rem;
-  line-height: 1.5;
+  line-height: 1.6;
 }
 
 /* Typography */
 h1, h2, h3, h4, h5, h6 {
+  font-family: var(--font-luxe);
   font-weight: 600;
-  line-height: 1.2;
+  letter-spacing: 0.01em;
+  line-height: 1.15;
+  color: var(--primary);
 }
 
 h1 {
@@ -91,7 +96,7 @@ h3 {
 a {
   color: var(--accent-strong);
   text-decoration: none;
-  transition: color 0.2s ease;
+  transition: color 0.15s ease;
 
   &:hover {
     color: var(--primary);
@@ -101,7 +106,7 @@ a {
 /* Buttons */
 button {
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
   border: none;
   border-radius: 999px;
 }
@@ -184,5 +189,10 @@ select {
   border: 1px solid var(--border-light);
   border-radius: 1rem;
   box-shadow: 0 12px 28px -24px rgb(122 54 95 / 55%);
+}
+
+.luxe-title {
+  font-family: var(--font-luxe);
+  letter-spacing: 0.02em;
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,12 +5,16 @@
 
 /* Global CSS Variables */
 :root {
-  --primary: #1f2937;
-  --secondary: #059669;
-  --accent: #f59e0b;
-  --text-dark: #1f2937;
-  --text-light: #f3f4f6;
-  --border-light: #e5e7eb;
+  --primary: #7a365f;
+  --secondary: #d56fa1;
+  --accent: #f3b9d4;
+  --accent-strong: #c24d83;
+  --surface: #fff8fc;
+  --surface-alt: #ffeef7;
+  --text-dark: #3d2031;
+  --text-light: #fff8fc;
+  --text-muted: #8f667c;
+  --border-light: #f0cfdf;
 }
 
 /* Accessibility: skip link (hidden until focused) */
@@ -36,9 +40,9 @@
   margin: 0;
   overflow: visible;
   clip: auto;
-  background: var(--accent);
-  color: var(--primary);
-  border-radius: 0.375rem;
+  background: var(--primary);
+  color: var(--text-light);
+  border-radius: 999px;
   font-weight: 600;
 }
 
@@ -51,9 +55,12 @@
 
 html, body {
   height: 100%;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+  font-family: "Avenir Next", "Avenir", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   color: var(--text-dark);
-  background-color: #f9fafb;
+  background-color: var(--surface);
+  background-image: radial-gradient(circle at 15% 20%, #ffe0ee 0%, transparent 32%),
+    radial-gradient(circle at 85% 0%, #ffd3e8 0%, transparent 28%), linear-gradient(180deg, #fff9fc 0%, #fff2f8 100%);
+  background-attachment: fixed;
 }
 
 body {
@@ -82,21 +89,21 @@ h3 {
 
 /* Links */
 a {
-  color: var(--secondary);
+  color: var(--accent-strong);
   text-decoration: none;
-  transition: color 0.3s ease;
+  transition: color 0.2s ease;
 
   &:hover {
-    color: darken(#059669, 10%);
+    color: var(--primary);
   }
 }
 
 /* Buttons */
 button {
   cursor: pointer;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
   border: none;
-  border-radius: 0.375rem;
+  border-radius: 999px;
 }
 
 /* Form Elements */
@@ -106,20 +113,21 @@ select {
   font-family: inherit;
   font-size: inherit;
   border: 1px solid var(--border-light);
-  border-radius: 0.375rem;
-  padding: 0.5rem;
+  border-radius: 0.85rem;
+  padding: 0.625rem 0.75rem;
+  background: #ffffff;
   transition: border-color 0.3s ease;
 
   &:focus {
     outline: none;
     border-color: var(--secondary);
-    box-shadow: 0 0 0 3px rgba(5, 150, 105, 0.1);
+    box-shadow: 0 0 0 4px rgb(213 111 161 / 18%);
   }
 }
 
 /* Utility Classes */
 .container {
-  max-width: 1200px;
+  max-width: 1240px;
   margin: 0 auto;
   padding: 0 1rem;
 }
@@ -154,7 +162,7 @@ select {
 
 /* Page layout consistency */
 .page-container {
-  max-width: 1200px;
+  max-width: 1240px;
   margin-left: auto;
   margin-right: auto;
   padding-left: 1rem;
@@ -164,9 +172,17 @@ select {
 }
 
 .card-container {
-  background: white;
-  border-radius: 0.5rem;
-  box-shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1);
+  background: #fff;
+  border: 1px solid var(--border-light);
+  border-radius: 1rem;
+  box-shadow: 0 12px 28px -24px rgb(122 54 95 / 55%);
   padding: 1.5rem;
+}
+
+.pinterest-panel {
+  background: linear-gradient(160deg, #ffffff 0%, var(--surface-alt) 100%);
+  border: 1px solid var(--border-light);
+  border-radius: 1rem;
+  box-shadow: 0 12px 28px -24px rgb(122 54 95 / 55%);
 }
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -62,7 +62,12 @@ html, body {
   background-color: var(--surface);
   background-image: radial-gradient(circle at 15% 20%, #ffe0ee 0%, transparent 32%),
     radial-gradient(circle at 85% 0%, #ffd3e8 0%, transparent 28%), linear-gradient(180deg, #fff9fc 0%, #fff2f8 100%);
-  background-attachment: fixed;
+}
+
+@media (min-width: 768px) {
+  html, body {
+    background-attachment: fixed;
+  }
 }
 
 body {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- apply a global pastel rose design system via CSS variables and shared surfaces
- redesign header and footer to a minimalist, classy Pinterest-inspired look
- modernize reusable UI components (cards, buttons, form fields, pagination, notifications)
- restyle key pages (reviews list/detail/form, auth pages, blog pages) to match the new visual identity
- add a second visual pass with a discreet luxury typography treatment (serif display headings + readable sans body)
- tone down motion/hover effects to keep a professional blog experience
- address PR review feedback on accessibility, token consistency, and robust Tailwind usage

## Review feedback addressed
- replaced unsupported Tailwind opacity-on-CSS-variable footer background class with a valid token-safe class
- removed conflicting base text color and redundant Tailwind animation class in notifications
- replaced hardcoded textarea colors with design tokens
- improved header brand accessibility by hiding decorative emoji from assistive tech
- removed dead placeholder footer links (`href="#"`) and replaced with disabled text placeholders
- prevented disabled buttons from showing hover shadow feedback
- reduced mobile paint cost by applying `background-attachment: fixed` only from `md` breakpoint
- removed runtime Google Fonts external dependency from `index.html` (keeps privacy/self-hosted compatibility)

## Testing
- `npm run build` *(cannot run in this environment because Angular CLI binary `ng` is unavailable)*

## Notes
- no functional business logic was changed; this update focuses on visual design, accessibility, and UX styling consistency

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-889c9622-e673-41ed-9a4f-d4de92a385f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-889c9622-e673-41ed-9a4f-d4de92a385f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

