### PR TITLE
ci: add GitHub Actions continuous integration pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
-      - "cursor/**"
+      - "**"
   pull_request:
     branches:
       - main

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,74 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - "cursor/**"
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  frontend:
+    name: Frontend (lint, test, build)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests (CI)
+        run: npm run test:ci
+
+      - name: Production build
+        run: npm run build:prod
+
+      - name: Upload frontend artifact
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: frontend-dist
+          path: dist/book-review-blog
+          if-no-files-found: error
+
+  api:
+    name: API (build)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: api
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: api/package-lock.json
+
+      - name: Install API dependencies
+        run: npm ci
+
+      - name: Build API
+        run: npm run build

--- a/.github/workflows/deploy-ynh.yml
+++ b/.github/workflows/deploy-ynh.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Resolve deployment configuration
         env:
           DEFAULT_APP_ID: book-review-blog
-          DEFAULT_SOURCE_URL: https://github.com/${{ github.repository }}
+          DEFAULT_SOURCE_URL: https://github.com/rdarocha-bcg/book-review-blog_ynh
           VAR_APP_ID: ${{ vars.YNH_APP_INSTANCE_ID }}
           VAR_SOURCE_URL: ${{ vars.YNH_APP_SOURCE_URL }}
           VAR_SSH_PORT: ${{ vars.YNH_SSH_PORT }}
@@ -41,28 +41,38 @@ jobs:
           SOURCE_URL="${VAR_SOURCE_URL:-$DEFAULT_SOURCE_URL}"
           SSH_PORT="${VAR_SSH_PORT:-22}"
 
+          case "$SOURCE_URL" in
+            *_ynh|*_ynh.git)
+              ;;
+            *)
+              echo "::error::SOURCE_URL must target a YunoHost packaging repository ending with '_ynh'."
+              exit 1
+              ;;
+          esac
+
           echo "APP_ID=$APP_ID" >> "$GITHUB_ENV"
           echo "SOURCE_URL=$SOURCE_URL" >> "$GITHUB_ENV"
           echo "SSH_PORT=$SSH_PORT" >> "$GITHUB_ENV"
 
       - name: Setup SSH private key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.YNH_SSH_PRIVATE_KEY }}
         run: |
           mkdir -p "$HOME/.ssh"
           chmod 700 "$HOME/.ssh"
-          printf '%s\n' "${{ secrets.YNH_SSH_PRIVATE_KEY }}" > "$HOME/.ssh/id_ed25519"
+          printf '%s\n' "$SSH_PRIVATE_KEY" > "$HOME/.ssh/id_ed25519"
           chmod 600 "$HOME/.ssh/id_ed25519"
 
       - name: Configure SSH known hosts
         env:
           SSH_HOST: ${{ secrets.YNH_SSH_HOST }}
-          SSH_PORT: ${{ env.SSH_PORT }}
           KNOWN_HOSTS: ${{ secrets.YNH_SSH_KNOWN_HOSTS }}
         run: |
-          if [ -n "$KNOWN_HOSTS" ]; then
-            printf '%s\n' "$KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
-          else
-            ssh-keyscan -p "$SSH_PORT" "$SSH_HOST" > "$HOME/.ssh/known_hosts"
+          if [ -z "$KNOWN_HOSTS" ]; then
+            echo "::error::Missing required secret YNH_SSH_KNOWN_HOSTS."
+            exit 1
           fi
+          printf '%s\n' "$KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
           chmod 600 "$HOME/.ssh/known_hosts"
 
       - name: Trigger YunoHost app upgrade
@@ -74,5 +84,9 @@ jobs:
           SOURCE_URL: ${{ env.SOURCE_URL }}
         run: |
           ssh -i "$HOME/.ssh/id_ed25519" -p "$SSH_PORT" \
+            -o BatchMode=yes \
+            -o StrictHostKeyChecking=yes \
+            -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+            -o IdentitiesOnly=yes \
             "$SSH_USER@$SSH_HOST" \
             "yunohost app upgrade '$APP_ID' -u '$SOURCE_URL'"

--- a/.github/workflows/deploy-ynh.yml
+++ b/.github/workflows/deploy-ynh.yml
@@ -19,6 +19,8 @@ jobs:
   deploy:
     name: Upgrade app on YunoHost
     runs-on: ubuntu-latest
+    environment:
+      name: production
     if: >-
       (github.event_name == 'workflow_dispatch') ||
       (github.event_name == 'workflow_run' &&

--- a/.github/workflows/deploy-ynh.yml
+++ b/.github/workflows/deploy-ynh.yml
@@ -1,0 +1,76 @@
+name: Deploy to YunoHost
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+    types:
+      - completed
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: deploy-ynh-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Upgrade app on YunoHost
+    runs-on: ubuntu-latest
+    if: >-
+      (github.event_name == 'workflow_dispatch') ||
+      (github.event_name == 'workflow_run' &&
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.full_name == github.repository)
+
+    steps:
+      - name: Resolve deployment configuration
+        env:
+          DEFAULT_APP_ID: book-review-blog
+          DEFAULT_SOURCE_URL: https://github.com/${{ github.repository }}
+          VAR_APP_ID: ${{ vars.YNH_APP_INSTANCE_ID }}
+          VAR_SOURCE_URL: ${{ vars.YNH_APP_SOURCE_URL }}
+          VAR_SSH_PORT: ${{ vars.YNH_SSH_PORT }}
+        run: |
+          APP_ID="${VAR_APP_ID:-$DEFAULT_APP_ID}"
+          SOURCE_URL="${VAR_SOURCE_URL:-$DEFAULT_SOURCE_URL}"
+          SSH_PORT="${VAR_SSH_PORT:-22}"
+
+          echo "APP_ID=$APP_ID" >> "$GITHUB_ENV"
+          echo "SOURCE_URL=$SOURCE_URL" >> "$GITHUB_ENV"
+          echo "SSH_PORT=$SSH_PORT" >> "$GITHUB_ENV"
+
+      - name: Setup SSH private key
+        run: |
+          mkdir -p "$HOME/.ssh"
+          chmod 700 "$HOME/.ssh"
+          printf '%s\n' "${{ secrets.YNH_SSH_PRIVATE_KEY }}" > "$HOME/.ssh/id_ed25519"
+          chmod 600 "$HOME/.ssh/id_ed25519"
+
+      - name: Configure SSH known hosts
+        env:
+          SSH_HOST: ${{ secrets.YNH_SSH_HOST }}
+          SSH_PORT: ${{ env.SSH_PORT }}
+          KNOWN_HOSTS: ${{ secrets.YNH_SSH_KNOWN_HOSTS }}
+        run: |
+          if [ -n "$KNOWN_HOSTS" ]; then
+            printf '%s\n' "$KNOWN_HOSTS" > "$HOME/.ssh/known_hosts"
+          else
+            ssh-keyscan -p "$SSH_PORT" "$SSH_HOST" > "$HOME/.ssh/known_hosts"
+          fi
+          chmod 600 "$HOME/.ssh/known_hosts"
+
+      - name: Trigger YunoHost app upgrade
+        env:
+          SSH_HOST: ${{ secrets.YNH_SSH_HOST }}
+          SSH_USER: ${{ secrets.YNH_SSH_USER }}
+          SSH_PORT: ${{ env.SSH_PORT }}
+          APP_ID: ${{ env.APP_ID }}
+          SOURCE_URL: ${{ env.SOURCE_URL }}
+        run: |
+          ssh -i "$HOME/.ssh/id_ed25519" -p "$SSH_PORT" \
+            "$SSH_USER@$SSH_HOST" \
+            "yunohost app upgrade '$APP_ID' -u '$SOURCE_URL'"

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -54,6 +54,17 @@ Set these in **Repository settings > Secrets and variables > Actions**:
 - Keep CI as the quality gate before deployment.
 - If your YunoHost instance id is not `book-review-blog`, set `YNH_APP_INSTANCE_ID`.
 - For production hardening, prefer setting `YNH_SSH_KNOWN_HOSTS` explicitly.
+- The workflow targets the GitHub **Environment** named `production`.
+
+### Recommended protection (required for manual approval)
+
+In **Repository settings > Environments > production**:
+
+1. Create (or edit) the `production` environment.
+2. Add **Required reviewers** (you and/or trusted maintainers).
+3. Optionally restrict deployable branches (for example `main` only).
+
+With this setup, each deployment run pauses until approved in GitHub Actions.
 
 ---
 

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -37,23 +37,19 @@ Set these in **Repository settings > Secrets and variables > Actions**:
 - `YNH_SSH_HOST`: server hostname or IP
 - `YNH_SSH_USER`: SSH user allowed to run `yunohost app upgrade` (usually with sudo/root rights)
 - `YNH_SSH_PRIVATE_KEY`: private key matching the public key installed on the server
-
-### Optional secret
-
-- `YNH_SSH_KNOWN_HOSTS`: full known_hosts line(s) for host key pinning
-  - when omitted, the workflow uses `ssh-keyscan` during runtime
+- `YNH_SSH_KNOWN_HOSTS`: full known_hosts line(s) for strict host key pinning
 
 ### Optional repository variables
 
 - `YNH_APP_INSTANCE_ID` (default: `book-review-blog`)
-- `YNH_APP_SOURCE_URL` (default: `https://github.com/<owner>/<repo>`)
+- `YNH_APP_SOURCE_URL` (default: `https://github.com/rdarocha-bcg/book-review-blog_ynh`)
 - `YNH_SSH_PORT` (default: `22`)
 
 ### Notes
 
 - Keep CI as the quality gate before deployment.
 - If your YunoHost instance id is not `book-review-blog`, set `YNH_APP_INSTANCE_ID`.
-- For production hardening, prefer setting `YNH_SSH_KNOWN_HOSTS` explicitly.
+- The workflow enforces strict host key checking using `YNH_SSH_KNOWN_HOSTS`.
 - The workflow targets the GitHub **Environment** named `production`.
 
 ### Recommended protection (required for manual approval)

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -15,6 +15,48 @@ See [YUNOHOST_INTEGRATION.md](YUNOHOST_INTEGRATION.md) and [doc/PRE_INSTALL.md](
 
 ---
 
+## Continuous deployment to YunoHost (GitHub Actions)
+
+This repository includes `.github/workflows/deploy-ynh.yml`.
+
+Deployment triggers:
+
+- automatically after the `CI` workflow succeeds on branch `main`
+- manually with **Actions > Deploy to YunoHost > Run workflow**
+
+The workflow connects over SSH and runs:
+
+```bash
+yunohost app upgrade <app_id> -u <source_url>
+```
+
+### Required GitHub secrets
+
+Set these in **Repository settings > Secrets and variables > Actions**:
+
+- `YNH_SSH_HOST`: server hostname or IP
+- `YNH_SSH_USER`: SSH user allowed to run `yunohost app upgrade` (usually with sudo/root rights)
+- `YNH_SSH_PRIVATE_KEY`: private key matching the public key installed on the server
+
+### Optional secret
+
+- `YNH_SSH_KNOWN_HOSTS`: full known_hosts line(s) for host key pinning
+  - when omitted, the workflow uses `ssh-keyscan` during runtime
+
+### Optional repository variables
+
+- `YNH_APP_INSTANCE_ID` (default: `book-review-blog`)
+- `YNH_APP_SOURCE_URL` (default: `https://github.com/<owner>/<repo>`)
+- `YNH_SSH_PORT` (default: `22`)
+
+### Notes
+
+- Keep CI as the quality gate before deployment.
+- If your YunoHost instance id is not `book-review-blog`, set `YNH_APP_INSTANCE_ID`.
+- For production hardening, prefer setting `YNH_SSH_KNOWN_HOSTS` explicitly.
+
+---
+
 ## Manual / generic hosting
 
 ### Frontend only

--- a/GIT_AND_RELEASE.md
+++ b/GIT_AND_RELEASE.md
@@ -96,9 +96,28 @@ Typical flow:
 
 ---
 
-## 4. Optional: CI (GitHub Actions)
+## 4. Continuous Integration (GitHub Actions)
 
-You can add a workflow that runs `npm ci`, `npm run lint`, and `npm run build:prod` on each push. Example file name: `.github/workflows/ci.yml` (create when you need it).
+The repository includes `.github/workflows/ci.yml` with two jobs on each `push` / `pull_request`:
+
+- **Frontend:** `npm ci`, `npm run lint`, `npm run test:ci`, `npm run build:prod`
+- **API:** `cd api && npm ci && npm run build`
+
+The workflow also uploads the frontend artifact (`dist/book-review-blog`) for traceability.
+
+### Why this helps for YunoHost
+
+Even if deployment is done by YunoHost install/upgrade scripts, CI validates that:
+
+- Angular production build is still healthy
+- unit tests and linting pass before merge
+- API TypeScript build remains valid
+
+This is the recommended baseline before adding deployment automation.
+
+### Optional next step: deployment automation
+
+For full CD, keep this CI as a quality gate and then trigger deployment from your release process (for example: tag/release-driven sync to `book-review-blog_ynh`, then `yunohost app upgrade` on server).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Use **Node for Windows** and a normal terminal if you want to avoid WSL.
 
 A CI workflow is available in `.github/workflows/ci.yml`.
 
-It runs on each push (main + `cursor/**`) and on pull requests to `main`, and executes:
+It runs on each push (all branches) and on pull requests to `main`, and executes:
 
 1. Frontend: `npm ci`, `npm run lint`, `npm run test:ci`, `npm run build:prod`
 2. API: `cd api && npm ci && npm run build`

--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ Use **Node for Windows** and a normal terminal if you want to avoid WSL.
 | `npm run test:coverage` | Tests with coverage report |
 | `npm run lint` | Lint (ESLint) |
 
+## Continuous integration (GitHub Actions)
+
+A CI workflow is available in `.github/workflows/ci.yml`.
+
+It runs on each push (main + `cursor/**`) and on pull requests to `main`, and executes:
+
+1. Frontend: `npm ci`, `npm run lint`, `npm run test:ci`, `npm run build:prod`
+2. API: `cd api && npm ci && npm run build`
+
+When frontend checks pass, the production build is uploaded as a GitHub artifact (`frontend-dist`).
+
 ## Documentation
 
 | Document | Purpose |

--- a/YUNOHOST_INTEGRATION.md
+++ b/YUNOHOST_INTEGRATION.md
@@ -32,7 +32,7 @@ yunohost app install https://github.com/rdarocha-bcg/book-review-blog_ynh
 
 Upgrade: `yunohost app upgrade book-review-blog -u https://github.com/rdarocha-bcg/book-review-blog_ynh` (replace `book-review-blog` with your instance id if multi-instance).
 
-Continuous deployment via GitHub Actions is available in `.github/workflows/deploy-ynh.yml`. It connects over SSH and runs the same `yunohost app upgrade ...` command on your server after CI succeeds on `main` (or manually via workflow dispatch).
+Continuous deployment via GitHub Actions is available in `.github/workflows/deploy-ynh.yml`. It connects over SSH and runs the same `yunohost app upgrade ...` command on your server after CI succeeds on `main` (or manually via workflow dispatch), with `-u https://github.com/rdarocha-bcg/book-review-blog_ynh` as default source URL.
 
 Logs: `journalctl -u book-review-blog -f` (service name follows the instance).
 

--- a/YUNOHOST_INTEGRATION.md
+++ b/YUNOHOST_INTEGRATION.md
@@ -32,6 +32,8 @@ yunohost app install https://github.com/rdarocha-bcg/book-review-blog_ynh
 
 Upgrade: `yunohost app upgrade book-review-blog -u https://github.com/rdarocha-bcg/book-review-blog_ynh` (replace `book-review-blog` with your instance id if multi-instance).
 
+Continuous deployment via GitHub Actions is available in `.github/workflows/deploy-ynh.yml`. It connects over SSH and runs the same `yunohost app upgrade ...` command on your server after CI succeeds on `main` (or manually via workflow dispatch).
+
 Logs: `journalctl -u book-review-blog -f` (service name follows the instance).
 
 **Requirements:** YunoHost ≥ 12.0; see `manifest.toml` for RAM hints.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add continuous integration workflow (`.github/workflows/ci.yml`) for frontend + API checks
- add continuous deployment workflow to YunoHost (`.github/workflows/deploy-ynh.yml`)
- deployment runs automatically after CI success on `main`, or manually via workflow dispatch
- deployment executes `yunohost app upgrade <app_id> -u <source_url>` over SSH
- enforce a protected `production` GitHub environment on deployment job for manual approval
- harden deployment security and align source defaults with YunoHost packaging mirror requirements
- add documentation for CI/CD activation in `README.md`, `GIT_AND_RELEASE.md`, `DEPLOYMENT.md`, and `YUNOHOST_INTEGRATION.md`

## Validation
- `npm run lint` ✅
- `npm run test:ci` ✅ (114 tests)
- `npm run build:prod` ✅
- `cd api && npm ci && npm run build` ✅

## Review fixes applied
- private key is now passed via environment variable (`SSH_PRIVATE_KEY`) and not interpolated inline in shell script
- `YNH_SSH_KNOWN_HOSTS` is now required (workflow fails fast if missing)
- SSH command now enforces strict host key checking (`StrictHostKeyChecking=yes`, explicit known_hosts file)
- default deployment source URL now points explicitly to `https://github.com/rdarocha-bcg/book-review-blog_ynh`
- deployment docs now align with `_ynh` source default and required host key pinning

## Required GitHub configuration for CD
- Environment:
  - create `production`
  - add required reviewers (manual approval before deploy)
- Secrets:
  - `YNH_SSH_HOST`
  - `YNH_SSH_USER`
  - `YNH_SSH_PRIVATE_KEY`
  - `YNH_SSH_KNOWN_HOSTS`
- Optional variables:
  - `YNH_APP_INSTANCE_ID` (default `book-review-blog`)
  - `YNH_APP_SOURCE_URL` (default `https://github.com/rdarocha-bcg/book-review-blog_ynh`)
  - `YNH_SSH_PORT` (default `22`)

## Notes
- CD workflow includes concurrency control to avoid overlapping deployments
- automatic workflow_run deployment is restricted to successful CI runs from the same repository and `main` branch
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15147f8e-3162-4247-80bc-578fe292ee3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15147f8e-3162-4247-80bc-578fe292ee3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

