### PR TITLE
feat(a11y): Dark theme toggle, palette variables, reduced motion (#9)

### DIFF
--- a/src/app/core/services/theme.service.ts
+++ b/src/app/core/services/theme.service.ts
@@ -1,0 +1,88 @@
+import { Injectable, Inject, signal } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
+
+export type ThemePreference = 'system' | 'light' | 'dark';
+
+const STORAGE_KEY = 'app-color-scheme';
+
+/**
+ * Applies light/dark appearance on <html> and persists user choice in localStorage.
+ * Initial paint is handled by a small inline script in index.html (same key).
+ */
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  readonly preference = signal<ThemePreference>(this.readStored());
+
+  private mediaQuery: MediaQueryList | null = null;
+
+  constructor(@Inject(DOCUMENT) private document: Document) {
+    const win = this.document.defaultView;
+    if (win?.matchMedia) {
+      this.mediaQuery = win.matchMedia('(prefers-color-scheme: dark)');
+      this.mediaQuery.addEventListener('change', () => {
+        if (this.preference() === 'system') {
+          this.applyToDocument('system');
+        }
+      });
+    }
+    this.applyToDocument(this.preference());
+  }
+
+  cyclePreference(): void {
+    const order: ThemePreference[] = ['system', 'light', 'dark'];
+    const idx = order.indexOf(this.preference());
+    const next = order[(idx + 1) % order.length];
+    this.setPreference(next);
+  }
+
+  setPreference(value: ThemePreference): void {
+    this.preference.set(value);
+    try {
+      this.document.defaultView?.localStorage?.setItem(STORAGE_KEY, value);
+    } catch {
+      /* ignore private mode */
+    }
+    this.applyToDocument(value);
+  }
+
+  labelForPreference(): string {
+    switch (this.preference()) {
+      case 'light':
+        return 'Light theme';
+      case 'dark':
+        return 'Dark theme';
+      default:
+        return 'System theme';
+    }
+  }
+
+  private readStored(): ThemePreference {
+    try {
+      const raw = this.document.defaultView?.localStorage?.getItem(STORAGE_KEY);
+      if (raw === 'light' || raw === 'dark' || raw === 'system') {
+        return raw;
+      }
+    } catch {
+      /* ignore */
+    }
+    return 'system';
+  }
+
+  private prefersDarkScheme(): boolean {
+    return this.mediaQuery?.matches ?? false;
+  }
+
+  private applyToDocument(pref: ThemePreference): void {
+    const root = this.document.documentElement;
+    let dark = false;
+    if (pref === 'dark') {
+      dark = true;
+    } else if (pref === 'light') {
+      dark = false;
+    } else {
+      dark = this.prefersDarkScheme();
+    }
+    root.classList.toggle('theme-dark', dark);
+    root.style.colorScheme = dark ? 'dark' : 'light';
+  }
+}

--- a/src/app/shared/components/button/button.component.spec.ts
+++ b/src/app/shared/components/button/button.component.spec.ts
@@ -36,21 +36,21 @@ describe('ButtonComponent', () => {
 
   it('should apply primary variant classes by default', () => {
     const classes = component.getClasses();
-    expect(classes).toContain('bg-[var(--accent)]');
-    expect(classes).toContain('text-[var(--primary)]');
+    expect(classes).toContain('bg-[var(--primary)]');
+    expect(classes).toContain('text-[var(--text-light)]');
   });
 
   it('should apply secondary variant classes when set', () => {
     component.variant = 'secondary';
     const classes = component.getClasses();
-    expect(classes).toContain('bg-slate-700');
-    expect(classes).toContain('text-white');
+    expect(classes).toContain('bg-[var(--secondary)]');
+    expect(classes).toContain('text-[var(--text-light)]');
   });
 
   it('should apply danger variant classes when set', () => {
     component.variant = 'danger';
     const classes = component.getClasses();
-    expect(classes).toContain('bg-red-600');
+    expect(classes).toContain('bg-rose-600');
   });
 
   it('should apply size classes', () => {

--- a/src/app/shared/components/button/button.component.ts
+++ b/src/app/shared/components/button/button.component.ts
@@ -21,11 +21,31 @@ export type ButtonSize = 'sm' | 'md' | 'lg';
     >
       <span *ngIf="!isLoading">{{ label }}</span>
       <span *ngIf="isLoading" class="flex items-center gap-2">
-        <div class="animate-spin rounded-full h-4 w-4 border-b-2 border-current"></div>
+        <div class="app-btn-spinner h-4 w-4 rounded-full border-b-2 border-current"></div>
         Loading...
       </span>
     </button>
   `,
+  styles: [
+    `
+      @keyframes app-btn-spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .app-btn-spinner {
+        animation: app-btn-spin 0.75s linear infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .app-btn-spinner {
+          animation: none;
+          border-width: 2px;
+          border-style: solid;
+          border-color: currentColor;
+        }
+      }
+    `,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ButtonComponent {
@@ -44,7 +64,7 @@ export class ButtonComponent {
 
     const variantClasses: Record<ButtonVariant, string> = {
       primary: 'bg-[var(--primary)] text-[var(--text-light)] hover:brightness-110',
-      secondary: 'bg-[var(--secondary)] text-white hover:brightness-105',
+      secondary: 'bg-[var(--secondary)] text-[var(--text-light)] hover:brightness-105',
       danger: 'bg-rose-600 text-white hover:bg-rose-700',
       ghost: 'bg-white/80 border border-[var(--border-light)] text-[var(--text-dark)] hover:bg-[var(--surface-alt)]',
     };

--- a/src/app/shared/components/card/card.component.spec.ts
+++ b/src/app/shared/components/card/card.component.spec.ts
@@ -21,24 +21,22 @@ describe('CardComponent', () => {
 
   it('should apply base card classes', () => {
     const classes = component.getClasses();
-    expect(classes).toContain('bg-white');
-    expect(classes).toContain('rounded-lg');
-    expect(classes).toContain('shadow');
-    expect(classes).toContain('p-4');
+    expect(classes).toContain('var(--card-bg)');
+    expect(classes).toContain('rounded-2xl');
+    expect(classes).toContain('p-5');
   });
 
   it('should add hover classes when hoverable is true', () => {
     component.hoverable = true;
     const classes = component.getClasses();
-    expect(classes).toContain('hover:shadow-lg');
-    expect(classes).toContain('transition-shadow');
     expect(classes).toContain('cursor-pointer');
+    expect(classes).toContain('transition-shadow');
   });
 
   it('should not add hover classes when hoverable is false', () => {
     component.hoverable = false;
     const classes = component.getClasses();
-    expect(classes).not.toContain('hover:shadow-lg');
+    expect(classes).not.toContain('cursor-pointer');
   });
 
   it('should display title when provided', () => {

--- a/src/app/shared/components/card/card.component.ts
+++ b/src/app/shared/components/card/card.component.ts
@@ -22,7 +22,8 @@ export class CardComponent {
   @Input() hoverable: boolean = false;
 
   getClasses(): string {
-    let classes = 'bg-white/95 border border-[var(--border-light)] rounded-2xl shadow-[0_12px_24px_-24px_rgba(122,54,95,0.55)] p-5';
+    let classes =
+      'bg-[color:var(--card-bg)] border border-[var(--border-light)] rounded-2xl shadow-[0_12px_24px_-24px_rgba(122,54,95,0.55)] p-5';
     if (this.hoverable) {
       classes += ' hover:shadow-[0_15px_28px_-24px_rgba(122,54,95,0.62)] transition-shadow duration-200 cursor-pointer';
     }

--- a/src/app/shared/components/header/header.component.spec.ts
+++ b/src/app/shared/components/header/header.component.spec.ts
@@ -7,6 +7,7 @@ import { AuthService } from '@core/services/auth.service';
 import { SiteConfigService } from '@core/services/site-config.service';
 import { DEFAULT_SITE_CONFIG } from '@core/models/site-config.model';
 import { SSO_LOGOUT_REDIRECT } from '@core/tokens/sso-redirect.token';
+import { ThemeService } from '@core/services/theme.service';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
@@ -71,5 +72,18 @@ describe('HeaderComponent', () => {
     const nav = el.querySelector('nav[aria-label="Main navigation"]');
     expect(skip).toBeTruthy();
     expect(nav).toBeTruthy();
+  });
+
+  it('should cycle theme preference when theme control is activated', () => {
+    const theme = TestBed.inject(ThemeService);
+    const start = theme.preference();
+    const el = fixture.nativeElement as HTMLElement;
+    const btn = Array.from(el.querySelectorAll('button')).find((b) =>
+      b.getAttribute('aria-label')?.startsWith('Color theme'),
+    ) as HTMLButtonElement | undefined;
+    expect(btn).toBeTruthy();
+    btn!.click();
+    fixture.detectChanges();
+    expect(theme.preference()).not.toBe(start);
   });
 });

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { AuthService } from '@core/services/auth.service';
 import { SiteConfigService } from '@core/services/site-config.service';
+import { ThemeService } from '@core/services/theme.service';
 import { SSO_LOGOUT_REDIRECT } from '@core/tokens/sso-redirect.token';
 import { environment } from '@environments/environment';
 import { Subject } from 'rxjs';
@@ -16,10 +17,13 @@ import { Subject } from 'rxjs';
   standalone: true,
   imports: [CommonModule, RouterLink],
   template: `
-    <header class="sticky top-0 z-40 border-b border-[var(--border-light)] bg-[#fff9fc]/85 backdrop-blur-md" role="banner">
+    <header
+      class="sticky top-0 z-40 border-b border-[var(--border-light)] bg-[color:var(--header-bg)] backdrop-blur-md"
+      role="banner"
+    >
       <a href="#main-content" class="skip-link">Skip to main content</a>
       <nav
-        class="container mx-auto my-3 flex items-center justify-between gap-4 rounded-full border border-[var(--border-light)] bg-white/95 px-5 py-3 shadow-[0_10px_24px_-20px_rgba(122,54,95,0.8)]"
+        class="container mx-auto my-3 flex items-center justify-between gap-4 rounded-full border border-[var(--border-light)] bg-[color:var(--nav-bg)] px-5 py-3 shadow-[0_10px_24px_-20px_rgba(122,54,95,0.8)]"
         aria-label="Main navigation"
       >
         <div class="flex items-center gap-8">
@@ -54,13 +58,21 @@ import { Subject } from 'rxjs';
           </ul>
         </div>
         <div class="flex items-center gap-4">
+          <button
+            type="button"
+            class="rounded-full border border-[var(--border-light)] bg-[var(--surface-alt)] px-3 py-2 text-sm font-semibold text-[var(--primary)] hover:brightness-95"
+            [attr.aria-label]="'Color theme: ' + theme.labelForPreference()"
+            (click)="theme.cyclePreference()"
+          >
+            {{ theme.preference() === 'system' ? 'Auto' : theme.preference() === 'dark' ? 'Dark' : 'Light' }}
+          </button>
           <div *ngIf="currentUser$ | async as user" class="text-sm text-[var(--text-muted)]">
             Welcome, {{ user.name || user.email }}
           </div>
           <button
             *ngIf="isAuthenticated$ | async"
             routerLink="/reviews/new"
-            class="bg-[var(--secondary)] text-white px-4 py-2 rounded-full font-semibold hover:brightness-95 transition"
+            class="bg-[var(--secondary)] text-[var(--text-light)] px-4 py-2 rounded-full font-semibold hover:brightness-95 transition"
             aria-label="Create new review"
           >
             + New Review
@@ -89,6 +101,7 @@ import { Subject } from 'rxjs';
 })
 export class HeaderComponent implements OnDestroy {
   readonly site = inject(SiteConfigService);
+  readonly theme = inject(ThemeService);
   isAuthenticated$ = this.authService.isAuthenticated();
   currentUser$ = this.authService.getCurrentUser$();
   private destroy$ = new Subject<void>();

--- a/src/app/shared/components/loading-spinner/loading-spinner.component.spec.ts
+++ b/src/app/shared/components/loading-spinner/loading-spinner.component.spec.ts
@@ -25,12 +25,19 @@ describe('LoadingSpinnerComponent', () => {
     expect(container).toBeTruthy();
   });
 
-  it('should render a spinner element with animation classes', () => {
+  it('should render a spinner ring with size and border classes', () => {
     const el = fixture.nativeElement as HTMLElement;
-    const spinner = el.querySelector('.animate-spin.rounded-full');
+    const spinner = el.querySelector('.spinner-ring');
     expect(spinner).toBeTruthy();
     expect(spinner?.classList.contains('h-12')).toBe(true);
     expect(spinner?.classList.contains('w-12')).toBe(true);
     expect(spinner?.classList.contains('border-b-2')).toBe(true);
+  });
+
+  it('should expose status for assistive technologies', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const region = el.querySelector('[role="status"]');
+    expect(region).toBeTruthy();
+    expect(el.textContent).toContain('Loading');
   });
 });

--- a/src/app/shared/components/loading-spinner/loading-spinner.component.ts
+++ b/src/app/shared/components/loading-spinner/loading-spinner.component.ts
@@ -8,10 +8,31 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
   selector: 'app-loading-spinner',
   standalone: true,
   template: `
-    <div class="flex items-center justify-center py-8">
-      <div class="animate-spin rounded-full h-12 w-12 border-b-2 border-[var(--accent)]"></div>
+    <div class="flex items-center justify-center py-8" role="status" aria-live="polite">
+      <span class="sr-only">Loading</span>
+      <div class="spinner-ring h-12 w-12 rounded-full border-b-2 border-[var(--accent)]"></div>
     </div>
   `,
+  styles: [
+    `
+      @keyframes app-spinner-rotate {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .spinner-ring {
+        animation: app-spinner-rotate 0.85s linear infinite;
+      }
+      @media (prefers-reduced-motion: reduce) {
+        .spinner-ring {
+          animation: none;
+          border-width: 2px;
+          border-style: solid;
+          border-color: var(--accent);
+        }
+      }
+    `,
+  ],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LoadingSpinnerComponent {}

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -24,6 +24,7 @@ import { NotificationService, Notification } from '@core/services/notification.s
       <div
         *ngFor="let notification of notifications$ | async; trackBy: trackByNotificationId"
         [@slideIn]
+        [@slideIn.disabled]="prefersReducedMotion()"
         [class]="getNotificationClasses(notification.type)"
         role="alert"
         [attr.aria-live]="'polite'"
@@ -93,6 +94,13 @@ import { NotificationService, Notification } from '@core/services/notification.s
 })
 export class NotificationComponent {
   notifications$ = this.notificationService.getNotifications();
+
+  prefersReducedMotion(): boolean {
+    if (typeof matchMedia === 'undefined') {
+      return false;
+    }
+    return matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
 
   constructor(private notificationService: NotificationService) {}
 

--- a/src/index.html
+++ b/src/index.html
@@ -6,6 +6,26 @@
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">
+  <script>
+    (function () {
+      try {
+        var key = "app-color-scheme";
+        var pref = localStorage.getItem(key);
+        var systemDark =
+          window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+        var dark = pref === "dark" || (pref !== "light" && systemDark);
+        var root = document.documentElement;
+        if (dark) {
+          root.classList.add("theme-dark");
+          root.style.colorScheme = "dark";
+        } else {
+          root.style.colorScheme = "light";
+        }
+      } catch (e) {
+        /* ignore */
+      }
+    })();
+  </script>
 </head>
 <body>
   <app-root></app-root>

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -5,6 +5,7 @@
 
 /* Global CSS Variables */
 :root {
+  color-scheme: light;
   --primary: #7a365f;
   --secondary: #d56fa1;
   --accent: #f3b9d4;
@@ -15,8 +16,34 @@
   --text-light: #fff8fc;
   --text-muted: #8f667c;
   --border-light: #f0cfdf;
+  --header-bg: rgb(255 249 252 / 0.85);
+  --nav-bg: rgb(255 255 255 / 0.95);
+  --card-bg: rgb(255 255 255 / 0.95);
+  --input-bg: #ffffff;
+  --panel-bg-start: #ffffff;
+  --panel-bg-end: var(--surface-alt);
   --font-sans: "Inter", "Avenir Next", "Avenir", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   --font-luxe: "Cormorant Garamond", "Times New Roman", Georgia, serif;
+}
+
+html.theme-dark {
+  color-scheme: dark;
+  --primary: #f0cfe0;
+  --secondary: #e07aaa;
+  --accent: #5c3d52;
+  --accent-strong: #f3b9d4;
+  --surface: #1a1218;
+  --surface-alt: #261a22;
+  --text-dark: #f5eaf1;
+  --text-light: #fdf5f9;
+  --text-muted: #c9a9bc;
+  --border-light: #4a3545;
+  --header-bg: rgb(26 18 24 / 0.92);
+  --nav-bg: rgb(38 26 34 / 0.96);
+  --card-bg: rgb(42 30 40 / 0.94);
+  --panel-bg-start: #2d2029;
+  --panel-bg-end: #241a22;
+  --input-bg: #2a2029;
 }
 
 /* Accessibility: skip link (hidden until focused) */
@@ -62,6 +89,11 @@ html, body {
   background-color: var(--surface);
   background-image: radial-gradient(circle at 15% 20%, #ffe0ee 0%, transparent 32%),
     radial-gradient(circle at 85% 0%, #ffd3e8 0%, transparent 28%), linear-gradient(180deg, #fff9fc 0%, #fff2f8 100%);
+}
+
+html.theme-dark body {
+  background-image: radial-gradient(circle at 15% 20%, #3d2435 0%, transparent 35%),
+    radial-gradient(circle at 85% 0%, #2a1c28 0%, transparent 30%), linear-gradient(180deg, #1a1218 0%, #140f14 100%);
 }
 
 @media (min-width: 768px) {
@@ -125,7 +157,7 @@ select {
   border: 1px solid var(--border-light);
   border-radius: 0.85rem;
   padding: 0.625rem 0.75rem;
-  background: #ffffff;
+  background: var(--input-bg);
   transition: border-color 0.3s ease;
 
   &:focus {
@@ -190,14 +222,51 @@ select {
 }
 
 .pinterest-panel {
-  background: linear-gradient(160deg, #ffffff 0%, var(--surface-alt) 100%);
+  background: linear-gradient(160deg, var(--panel-bg-start) 0%, var(--panel-bg-end) 100%);
   border: 1px solid var(--border-light);
   border-radius: 1rem;
   box-shadow: 0 12px 28px -24px rgb(122 54 95 / 55%);
 }
 
+html.theme-dark .pinterest-panel {
+  box-shadow: 0 12px 28px -24px rgb(0 0 0 / 45%);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 .luxe-title {
   font-family: var(--font-luxe);
   letter-spacing: 0.02em;
+}
+
+/* Map common light-only Tailwind utilities when .theme-dark is on <html> */
+html.theme-dark .bg-white {
+  background-color: var(--card-bg) !important;
+}
+
+html.theme-dark .bg-white\/95 {
+  background-color: color-mix(in srgb, var(--card-bg) 95%, transparent) !important;
+}
+
+html.theme-dark .border-slate-200 {
+  border-color: var(--border-light) !important;
+}
+
+html.theme-dark .text-gray-600,
+html.theme-dark .text-slate-600 {
+  color: var(--text-muted) !important;
+}
+
+html.theme-dark .divide-slate-200 > :not([hidden]) ~ :not([hidden]) {
+  border-color: var(--border-light) !important;
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
### Reduced motion
- Global `@media (prefers-reduced-motion: reduce)` shortens transitions/animations and sets `scroll-behavior: auto`.
- **Toasts**: `[@slideIn.disabled]` when `prefers-reduced-motion: reduce` (no slide-in).
- **Loading spinner** and **button loading** indicator: static ring instead of spin when reduced motion.

### Dark theme (user + system)
- **`index.html` inline script** reads `localStorage` key `app-color-scheme` (`system` | `light` | `dark`) and toggles `theme-dark` on `<html>` before first paint (avoids flash).
- **`ThemeService`**: same key, cycles **system → light → dark**; updates `document.documentElement.classList` and `color-scheme`.
- **Header** control (Auto / Light / Dark) with `aria-label` describing current mode.

### Styling
- **`html.theme-dark`** overrides CSS variables (surfaces, text, borders, panel gradients).
- **`--card-bg`**, **`--header-bg`**, **`--nav-bg`**, **`--input-bg`** for surfaces; **Card** uses `--card-bg`.
- **Overrides** for common Tailwind `bg-white`, `border-slate-200`, `text-gray-600` under `.theme-dark` so admin/blog pages stay readable.

### Tests / fixes
- **Button** specs aligned with actual token-based classes; secondary label uses `text-[var(--text-light)]` for contrast on pink.
- **Card** spec expectations updated for current card classes.
- **Header** spec: theme button changes `ThemeService.preference`.

Closes #9.

## Validation
- `npm run lint` — pass
- `ng test` (header, card, button specs) — pass
- `npm run build:prod` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-fdeb423f-e3a0-4528-9181-aaa5ef002678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fdeb423f-e3a0-4528-9181-aaa5ef002678"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

