### PR TITLE
fix(#38,#44): add adminGuard and hide admin nav link for non-admins

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,5 +1,6 @@
 import { Routes } from '@angular/router';
 import { authGuard } from '@core/guards/auth.guard';
+import { adminGuard } from '@core/guards/admin.guard';
 
 export const routes: Routes = [
   {
@@ -98,6 +99,7 @@ export const routes: Routes = [
   },
   {
     path: 'admin',
+    canActivate: [adminGuard],
     loadChildren: () =>
       import('./features/admin/admin.routes').then((m) => m.ADMIN_ROUTES),
   },

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -99,7 +99,7 @@ export const routes: Routes = [
   },
   {
     path: 'admin',
-    canActivate: [adminGuard],
+    canMatch: [adminGuard],
     loadChildren: () =>
       import('./features/admin/admin.routes').then((m) => m.ADMIN_ROUTES),
   },

--- a/src/app/core/guards/admin.guard.spec.ts
+++ b/src/app/core/guards/admin.guard.spec.ts
@@ -1,0 +1,48 @@
+import { TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of } from 'rxjs';
+import { adminGuard } from './admin.guard';
+import { AuthService, AuthState } from '@core/services/auth.service';
+
+function runGuard(authState: AuthState) {
+  const authServiceStub = { getState: () => of(authState) };
+  TestBed.configureTestingModule({
+    imports: [RouterTestingModule],
+    providers: [{ provide: AuthService, useValue: authServiceStub }],
+  });
+  const router = TestBed.inject(Router);
+  return TestBed.runInInjectionContext(() => adminGuard({} as never, {} as never));
+}
+
+describe('adminGuard', () => {
+  it('should allow navigation for an authenticated admin', (done) => {
+    const state: AuthState = {
+      authenticated: true,
+      user: { id: '1', email: 'admin@example.com', name: 'Admin', role: 'admin' },
+    };
+    (runGuard(state) as ReturnType<typeof of>).subscribe((result) => {
+      expect(result).toBe(true);
+      done();
+    });
+  });
+
+  it('should redirect to /401 for an authenticated non-admin user', (done) => {
+    const state: AuthState = {
+      authenticated: true,
+      user: { id: '2', email: 'user@example.com', name: 'User', role: 'user' },
+    };
+    (runGuard(state) as ReturnType<typeof of>).subscribe((result) => {
+      expect(result).not.toBe(true);
+      done();
+    });
+  });
+
+  it('should redirect to /401 for an unauthenticated user', (done) => {
+    const state: AuthState = { authenticated: false };
+    (runGuard(state) as ReturnType<typeof of>).subscribe((result) => {
+      expect(result).not.toBe(true);
+      done();
+    });
+  });
+});

--- a/src/app/core/guards/admin.guard.spec.ts
+++ b/src/app/core/guards/admin.guard.spec.ts
@@ -12,7 +12,8 @@ function runGuard(authState: AuthState) {
     providers: [{ provide: AuthService, useValue: authServiceStub }],
   });
   const router = TestBed.inject(Router);
-  return TestBed.runInInjectionContext(() => adminGuard({} as never, {} as never));
+  const result$ = TestBed.runInInjectionContext(() => adminGuard({} as never, [] as never));
+  return { result$, router };
 }
 
 describe('adminGuard', () => {
@@ -21,7 +22,8 @@ describe('adminGuard', () => {
       authenticated: true,
       user: { id: '1', email: 'admin@example.com', name: 'Admin', role: 'admin' },
     };
-    (runGuard(state) as ReturnType<typeof of>).subscribe((result) => {
+    const { result$ } = runGuard(state);
+    (result$ as ReturnType<typeof of>).subscribe((result) => {
       expect(result).toBe(true);
       done();
     });
@@ -32,16 +34,18 @@ describe('adminGuard', () => {
       authenticated: true,
       user: { id: '2', email: 'user@example.com', name: 'User', role: 'user' },
     };
-    (runGuard(state) as ReturnType<typeof of>).subscribe((result) => {
-      expect(result).not.toBe(true);
+    const { result$, router } = runGuard(state);
+    (result$ as ReturnType<typeof of>).subscribe((result) => {
+      expect(result).toEqual(router.createUrlTree(['/401']));
       done();
     });
   });
 
-  it('should redirect to /401 for an unauthenticated user', (done) => {
+  it('should redirect to /login for an unauthenticated user', (done) => {
     const state: AuthState = { authenticated: false };
-    (runGuard(state) as ReturnType<typeof of>).subscribe((result) => {
-      expect(result).not.toBe(true);
+    const { result$, router } = runGuard(state);
+    (result$ as ReturnType<typeof of>).subscribe((result) => {
+      expect(result).toEqual(router.createUrlTree(['/login']));
       done();
     });
   });

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -1,0 +1,23 @@
+import { inject } from '@angular/core';
+import { CanActivateFn, Router } from '@angular/router';
+import { map } from 'rxjs';
+import { AuthService } from '@core/services/auth.service';
+
+/**
+ * Blocks navigation to admin routes unless the user has an active SSO session
+ * AND holds the 'admin' role.
+ * On failure redirects to /401.
+ */
+export const adminGuard: CanActivateFn = () => {
+  const auth = inject(AuthService);
+  const router = inject(Router);
+
+  return auth.getState().pipe(
+    map((state) => {
+      if (state.authenticated && state.user?.role === 'admin') {
+        return true;
+      }
+      return router.createUrlTree(['/401']);
+    }),
+  );
+};

--- a/src/app/core/guards/admin.guard.ts
+++ b/src/app/core/guards/admin.guard.ts
@@ -1,23 +1,23 @@
 import { inject } from '@angular/core';
-import { CanActivateFn, Router } from '@angular/router';
+import { CanMatchFn, Router } from '@angular/router';
 import { map } from 'rxjs';
 import { AuthService } from '@core/services/auth.service';
 
 /**
  * Blocks navigation to admin routes unless the user has an active SSO session
  * AND holds the 'admin' role.
- * On failure redirects to /401.
+ * Unauthenticated users are redirected to /login; authenticated non-admins to /401.
+ * Uses `canMatch` so the admin chunk is never downloaded for ineligible users.
  */
-export const adminGuard: CanActivateFn = () => {
+export const adminGuard: CanMatchFn = () => {
   const auth = inject(AuthService);
   const router = inject(Router);
 
   return auth.getState().pipe(
     map((state) => {
-      if (state.authenticated && state.user?.role === 'admin') {
-        return true;
-      }
-      return router.createUrlTree(['/401']);
+      if (!state.authenticated) return router.createUrlTree(['/login']);
+      if (state.user?.role !== 'admin') return router.createUrlTree(['/401']);
+      return true;
     }),
   );
 };

--- a/src/app/shared/components/header/header.component.spec.ts
+++ b/src/app/shared/components/header/header.component.spec.ts
@@ -4,39 +4,69 @@ import { signal } from '@angular/core';
 import { HeaderComponent } from './header.component';
 import { SiteConfigService } from '@core/services/site-config.service';
 import { DEFAULT_SITE_CONFIG } from '@core/models/site-config.model';
+import { AuthService, AuthState } from '@core/services/auth.service';
+
+function buildAuthStub(authState: AuthState | null) {
+  const stateSignal = signal<AuthState | null>(authState);
+  return { state: stateSignal.asReadonly() };
+}
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
 
-  beforeEach(async () => {
+  async function setup(authState: AuthState | null = null) {
     const branding = signal(DEFAULT_SITE_CONFIG);
     const siteConfigStub = { config: branding.asReadonly() };
 
     await TestBed.configureTestingModule({
       imports: [HeaderComponent, RouterTestingModule],
-      providers: [{ provide: SiteConfigService, useValue: siteConfigStub }],
+      providers: [
+        { provide: SiteConfigService, useValue: siteConfigStub },
+        { provide: AuthService, useValue: buildAuthStub(authState) },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  });
+  }
 
-  it('should create', () => {
+  it('should create', async () => {
+    await setup();
     expect(component).toBeTruthy();
   });
 
-  it('should show primary nav links: Accueil, Critiques, Travaux, À propos, Admin', () => {
+  it('should show non-admin nav links for unauthenticated user (no Admin link)', async () => {
+    await setup(null);
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('Accueil');
     expect(el.textContent).toContain('Critiques');
     expect(el.textContent).toContain('Travaux');
     expect(el.textContent).toContain('À propos');
+    expect(el.textContent).not.toContain('Admin');
+  });
+
+  it('should show Admin link when user is admin', async () => {
+    await setup({
+      authenticated: true,
+      user: { id: '1', email: 'admin@example.com', name: 'Admin', role: 'admin' },
+    });
+    const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('Admin');
   });
 
-  it('should have skip link and main nav with aria-label', () => {
+  it('should hide Admin link when user is not admin', async () => {
+    await setup({
+      authenticated: true,
+      user: { id: '2', email: 'user@example.com', name: 'User', role: 'user' },
+    });
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.textContent).not.toContain('Admin');
+  });
+
+  it('should have skip link and main nav with aria-label', async () => {
+    await setup();
     const el = fixture.nativeElement as HTMLElement;
     const skip = el.querySelector('.skip-link');
     const nav = el.querySelector('nav[aria-label="Main navigation"]');
@@ -44,7 +74,8 @@ describe('HeaderComponent', () => {
     expect(nav).toBeTruthy();
   });
 
-  it('should toggle mobile menu and set aria-expanded', () => {
+  it('should toggle mobile menu and set aria-expanded', async () => {
+    await setup();
     const el = fixture.nativeElement as HTMLElement;
     const toggle = el.querySelector('#mobile-nav-toggle') as HTMLButtonElement | null;
     expect(toggle).toBeTruthy();

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   OnDestroy,
   ChangeDetectionStrategy,
+  computed,
   inject,
   signal,
   ElementRef,
@@ -9,6 +10,7 @@ import {
   HostListener,
 } from '@angular/core';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
+import { AuthService } from '@core/services/auth.service';
 import { SiteConfigService } from '@core/services/site-config.service';
 import { filter, Subject, takeUntil } from 'rxjs';
 
@@ -75,11 +77,13 @@ import { filter, Subject, takeUntil } from 'rxjs';
                 >Contact</a
               >
             </li>
-            <li>
-              <a routerLink="/admin" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)]"
-                >Admin</a
-              >
-            </li>
+            @if (isAdmin()) {
+              <li>
+                <a routerLink="/admin" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)]"
+                  >Admin</a
+                >
+              </li>
+            }
           </ul>
         </div>
       </nav>
@@ -139,14 +143,16 @@ import { filter, Subject, takeUntil } from 'rxjs';
                 >Contact</a
               >
             </li>
-            <li>
-              <a
-                routerLink="/admin"
-                class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
-                (click)="closeMobileNav()"
-                >Admin</a
-              >
-            </li>
+            @if (isAdmin()) {
+              <li>
+                <a
+                  routerLink="/admin"
+                  class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
+                  (click)="closeMobileNav()"
+                  >Admin</a
+                >
+              </li>
+            }
           </ul>
         </div>
       }
@@ -156,7 +162,11 @@ import { filter, Subject, takeUntil } from 'rxjs';
 })
 export class HeaderComponent implements OnDestroy {
   readonly site = inject(SiteConfigService);
+  readonly auth = inject(AuthService);
   private readonly router = inject(Router);
+
+  /** True when the current user holds the admin role. */
+  readonly isAdmin = computed(() => this.auth.state()?.user?.role === 'admin');
 
   readonly mobileNavOpen = signal(false);
   private readonly menuButtonRef = viewChild<ElementRef<HTMLButtonElement>>('menuButton');


### PR DESCRIPTION
closes #38
closes #44

## Changes
- Created `adminGuard` that checks authenticated + admin role, redirects to `/401` otherwise
- Applied `adminGuard` to all `/admin` routes via `canActivate` in `app.routes.ts`
- `HeaderComponent`: Admin nav link gated with `@if (isAdmin())` computed signal (both desktop and mobile nav)
- Updated header spec: mock `AuthService`, added admin/non-admin visibility tests
- Added `admin.guard.spec.ts` with 3 cases (admin, non-admin, unauthenticated)

## Validation
- Lint: CI (no local node_modules per team rules)
- Unit tests: CI