### PR TITLE
fix(#39,#40): add routerLinkActive indicator and fix cancel button navigation

### DIFF
--- a/src/app/features/academics/pages/academic-form/academic-form.component.ts
+++ b/src/app/features/academics/pages/academic-form/academic-form.component.ts
@@ -520,6 +520,10 @@ export class AcademicFormComponent implements OnInit, OnDestroy {
   }
 
   onCancel(): void {
-    this.location.back();
+    if (window.history.length > 1) {
+      this.location.back();
+    } else {
+      this.router.navigate(['/']);
+    }
   }
 }

--- a/src/app/features/academics/pages/academic-form/academic-form.component.ts
+++ b/src/app/features/academics/pages/academic-form/academic-form.component.ts
@@ -7,7 +7,7 @@ import {
   viewChild,
   ElementRef,
 } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, Location } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
@@ -355,6 +355,7 @@ export class AcademicFormComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private http: HttpClient,
     private cdr: ChangeDetectorRef,
+    private location: Location,
   ) {
     this.initializeForm();
   }
@@ -519,6 +520,6 @@ export class AcademicFormComponent implements OnInit, OnDestroy {
   }
 
   onCancel(): void {
-    this.router.navigate(['/academics']);
+    this.location.back();
   }
 }

--- a/src/app/features/reviews/pages/review-form/review-form.component.ts
+++ b/src/app/features/reviews/pages/review-form/review-form.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy, ChangeDetectionStrategy } from '@angular/core';
-import { CommonModule } from '@angular/common';
+import { CommonModule, Location } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
 import { ReviewService } from '../../services/review.service';
@@ -213,7 +213,8 @@ export class ReviewFormComponent implements OnInit, OnDestroy {
     private reviewService: ReviewService,
     private notificationService: NotificationService,
     private router: Router,
-    private route: ActivatedRoute
+    private route: ActivatedRoute,
+    private location: Location
   ) {
     this.initializeForm();
   }
@@ -314,9 +315,9 @@ export class ReviewFormComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Cancel and go back
+   * Cancel and go back to the previous page
    */
   onCancel(): void {
-    this.router.navigate(['/']);
+    this.location.back();
   }
 }

--- a/src/app/features/reviews/pages/review-form/review-form.component.ts
+++ b/src/app/features/reviews/pages/review-form/review-form.component.ts
@@ -315,9 +315,13 @@ export class ReviewFormComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Cancel and go back to the previous page
+   * Cancel and go back to the previous page, with a fallback to home.
    */
   onCancel(): void {
-    this.location.back();
+    if (window.history.length > 1) {
+      this.location.back();
+    } else {
+      this.router.navigate(['/']);
+    }
   }
 }

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -9,7 +9,7 @@ import {
   viewChild,
   HostListener,
 } from '@angular/core';
-import { NavigationEnd, Router, RouterLink } from '@angular/router';
+import { NavigationEnd, Router, RouterLink, RouterLinkActive } from '@angular/router';
 import { AuthService } from '@core/services/auth.service';
 import { SiteConfigService } from '@core/services/site-config.service';
 import { filter, Subject, takeUntil } from 'rxjs';
@@ -20,7 +20,7 @@ import { filter, Subject, takeUntil } from 'rxjs';
 @Component({
   selector: 'app-header',
   standalone: true,
-  imports: [RouterLink],
+  imports: [RouterLink, RouterLinkActive],
   template: `
     <header
       class="relative sticky top-0 z-40 border-b border-[var(--border-light)] shadow-sm bg-[color:var(--header-bg)] backdrop-blur-md"
@@ -55,31 +55,52 @@ import { filter, Subject, takeUntil } from 'rxjs';
           </button>
           <ul class="hidden gap-6 md:flex">
             <li>
-              <a routerLink="/" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)]">Accueil</a>
+              <a
+                routerLink="/"
+                routerLinkActive="text-[var(--primary)] border-b-2 border-[var(--primary)]"
+                [routerLinkActiveOptions]="{ exact: true }"
+                class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] pb-0.5"
+                >Accueil</a
+              >
             </li>
             <li>
-              <a routerLink="/reviews" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)]"
+              <a
+                routerLink="/reviews"
+                routerLinkActive="text-[var(--primary)] border-b-2 border-[var(--primary)]"
+                class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] pb-0.5"
                 >Critiques</a
               >
             </li>
             <li>
-              <a routerLink="/academics" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)]"
+              <a
+                routerLink="/academics"
+                routerLinkActive="text-[var(--primary)] border-b-2 border-[var(--primary)]"
+                class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] pb-0.5"
                 >Travaux</a
               >
             </li>
             <li>
-              <a routerLink="/about" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)]"
+              <a
+                routerLink="/about"
+                routerLinkActive="text-[var(--primary)] border-b-2 border-[var(--primary)]"
+                class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] pb-0.5"
                 >À propos</a
               >
             </li>
             <li>
-              <a routerLink="/contact" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)]"
+              <a
+                routerLink="/contact"
+                routerLinkActive="text-[var(--primary)] border-b-2 border-[var(--primary)]"
+                class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] pb-0.5"
                 >Contact</a
               >
             </li>
             @if (isAdmin()) {
               <li>
-                <a routerLink="/admin" class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)]"
+                <a
+                  routerLink="/admin"
+                  routerLinkActive="text-[var(--primary)] border-b-2 border-[var(--primary)]"
+                  class="font-medium text-[var(--text-dark)] hover:text-[var(--accent-strong)] pb-0.5"
                   >Admin</a
                 >
               </li>
@@ -106,6 +127,8 @@ import { filter, Subject, takeUntil } from 'rxjs';
             <li>
               <a
                 routerLink="/"
+                routerLinkActive="bg-[var(--surface)] text-[var(--primary)] font-semibold"
+                [routerLinkActiveOptions]="{ exact: true }"
                 class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
                 (click)="closeMobileNav()"
                 >Accueil</a
@@ -114,6 +137,7 @@ import { filter, Subject, takeUntil } from 'rxjs';
             <li>
               <a
                 routerLink="/reviews"
+                routerLinkActive="bg-[var(--surface)] text-[var(--primary)] font-semibold"
                 class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
                 (click)="closeMobileNav()"
                 >Critiques</a
@@ -122,6 +146,7 @@ import { filter, Subject, takeUntil } from 'rxjs';
             <li>
               <a
                 routerLink="/academics"
+                routerLinkActive="bg-[var(--surface)] text-[var(--primary)] font-semibold"
                 class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
                 (click)="closeMobileNav()"
                 >Travaux</a
@@ -130,6 +155,7 @@ import { filter, Subject, takeUntil } from 'rxjs';
             <li>
               <a
                 routerLink="/about"
+                routerLinkActive="bg-[var(--surface)] text-[var(--primary)] font-semibold"
                 class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
                 (click)="closeMobileNav()"
                 >À propos</a
@@ -138,6 +164,7 @@ import { filter, Subject, takeUntil } from 'rxjs';
             <li>
               <a
                 routerLink="/contact"
+                routerLinkActive="bg-[var(--surface)] text-[var(--primary)] font-semibold"
                 class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
                 (click)="closeMobileNav()"
                 >Contact</a
@@ -147,6 +174,7 @@ import { filter, Subject, takeUntil } from 'rxjs';
               <li>
                 <a
                   routerLink="/admin"
+                  routerLinkActive="bg-[var(--surface)] text-[var(--primary)] font-semibold"
                   class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
                   (click)="closeMobileNav()"
                   >Admin</a


### PR DESCRIPTION
closes #39
closes #40

## Changes
- **#39** Active nav link highlighted via `routerLinkActive`: desktop links get a primary-color underline border; mobile links get a highlighted background. Home link uses `[routerLinkActiveOptions]="{ exact: true }"` to avoid always matching.
- **#40** Cancel buttons in `ReviewFormComponent` and `AcademicFormComponent` now use `location.back()` (Angular `Location` from `@angular/common`) instead of navigating to a hardcoded route.

## Validation
- Lint: pass (all files pass linting)
- Unit tests: pass (129/129 SUCCESS)