### PR TITLE
fix(#41,#45,#46): canDeactivate guard on forms and accessibility improvements

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { authGuard } from '@core/guards/auth.guard';
 import { adminGuard } from '@core/guards/admin.guard';
+import { canDeactivateGuard } from '@core/guards/can-deactivate.guard';
 
 export const routes: Routes = [
   {
@@ -35,6 +36,7 @@ export const routes: Routes = [
       {
         path: 'new',
         canActivate: [authGuard],
+        canDeactivate: [canDeactivateGuard],
         loadComponent: () =>
           import('./features/reviews/pages/review-form/review-form.component').then(
             (m) => m.ReviewFormComponent
@@ -53,6 +55,7 @@ export const routes: Routes = [
           {
             path: 'edit',
             canActivate: [authGuard],
+            canDeactivate: [canDeactivateGuard],
             loadComponent: () =>
               import('./features/reviews/pages/review-form/review-form.component').then(
                 (m) => m.ReviewFormComponent
@@ -75,6 +78,7 @@ export const routes: Routes = [
       {
         path: 'new',
         canActivate: [authGuard],
+        canDeactivate: [canDeactivateGuard],
         loadComponent: () =>
           import('./features/academics/pages/academic-form/academic-form.component').then(
             (m) => m.AcademicFormComponent
@@ -90,6 +94,7 @@ export const routes: Routes = [
       {
         path: ':id/edit',
         canActivate: [authGuard],
+        canDeactivate: [canDeactivateGuard],
         loadComponent: () =>
           import('./features/academics/pages/academic-form/academic-form.component').then(
             (m) => m.AcademicFormComponent

--- a/src/app/core/guards/can-deactivate.guard.spec.ts
+++ b/src/app/core/guards/can-deactivate.guard.spec.ts
@@ -1,0 +1,51 @@
+import { canDeactivateGuard, HasUnsavedChanges } from './can-deactivate.guard';
+
+describe('canDeactivateGuard', () => {
+  let confirmSpy: jasmine.Spy;
+
+  beforeEach(() => {
+    confirmSpy = spyOn(window, 'confirm');
+  });
+
+  it('should return true and call confirm when component is dirty and user confirms', () => {
+    confirmSpy.and.returnValue(true);
+    const component: HasUnsavedChanges = { hasUnsavedChanges: () => true };
+
+    const result = canDeactivateGuard(component, null!, null!, null!);
+
+    expect(confirmSpy).toHaveBeenCalledOnceWith(
+      'Vous avez des modifications non sauvegardées. Quitter quand même ?'
+    );
+    expect(result).toBeTrue();
+  });
+
+  it('should return false and call confirm when component is dirty and user cancels', () => {
+    confirmSpy.and.returnValue(false);
+    const component: HasUnsavedChanges = { hasUnsavedChanges: () => true };
+
+    const result = canDeactivateGuard(component, null!, null!, null!);
+
+    expect(confirmSpy).toHaveBeenCalledOnceWith(
+      'Vous avez des modifications non sauvegardées. Quitter quand même ?'
+    );
+    expect(result).toBeFalse();
+  });
+
+  it('should return true without calling confirm when component is clean', () => {
+    const component: HasUnsavedChanges = { hasUnsavedChanges: () => false };
+
+    const result = canDeactivateGuard(component, null!, null!, null!);
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(result).toBeTrue();
+  });
+
+  it('should return true safely when component does not implement HasUnsavedChanges', () => {
+    const component = {} as HasUnsavedChanges;
+
+    const result = canDeactivateGuard(component, null!, null!, null!);
+
+    expect(confirmSpy).not.toHaveBeenCalled();
+    expect(result).toBeTrue();
+  });
+});

--- a/src/app/core/guards/can-deactivate.guard.ts
+++ b/src/app/core/guards/can-deactivate.guard.ts
@@ -1,0 +1,17 @@
+import { CanDeactivateFn } from '@angular/router';
+
+/** Interface that form components must implement to support the guard. */
+export interface HasUnsavedChanges {
+  hasUnsavedChanges(): boolean;
+}
+
+/**
+ * Functional CanDeactivate guard.
+ * Prompts the user before navigating away from a dirty form.
+ */
+export const canDeactivateGuard: CanDeactivateFn<HasUnsavedChanges> = (component) => {
+  if (component.hasUnsavedChanges()) {
+    return window.confirm('Vous avez des modifications non sauvegardées. Quitter quand même ?');
+  }
+  return true;
+};

--- a/src/app/core/guards/can-deactivate.guard.ts
+++ b/src/app/core/guards/can-deactivate.guard.ts
@@ -10,7 +10,7 @@ export interface HasUnsavedChanges {
  * Prompts the user before navigating away from a dirty form.
  */
 export const canDeactivateGuard: CanDeactivateFn<HasUnsavedChanges> = (component) => {
-  if (component.hasUnsavedChanges()) {
+  if (component?.hasUnsavedChanges?.()) {
     return window.confirm('Vous avez des modifications non sauvegardées. Quitter quand même ?');
   }
   return true;

--- a/src/app/features/academics/pages/academic-form/academic-form.component.ts
+++ b/src/app/features/academics/pages/academic-form/academic-form.component.ts
@@ -15,6 +15,7 @@ import { AcademicService } from '../../services/academic.service';
 import { NotificationService } from '@core/services/notification.service';
 import { ButtonComponent } from '@shared/components/button/button.component';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { HasUnsavedChanges } from '@core/guards/can-deactivate.guard';
 import { Subject, takeUntil } from 'rxjs';
 import { MarkdownComponent } from 'ngx-markdown';
 
@@ -46,6 +47,7 @@ import { MarkdownComponent } from 'ngx-markdown';
               formControlName="title"
               placeholder="Titre du travail"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              aria-required="true"
               [attr.aria-invalid]="isFieldInvalid('title')"
             />
             <p *ngIf="isFieldInvalid('title')" class="text-red-600 text-sm mt-1">Le titre est requis</p>
@@ -60,6 +62,7 @@ import { MarkdownComponent } from 'ngx-markdown';
               placeholder="Résumé court du travail"
               rows="3"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              aria-required="true"
               [attr.aria-invalid]="isFieldInvalid('summary')"
             ></textarea>
             <p
@@ -198,6 +201,7 @@ import { MarkdownComponent } from 'ngx-markdown';
               id="workType"
               formControlName="workType"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              aria-required="true"
               [attr.aria-invalid]="isFieldInvalid('workType')"
             >
               <option value="">Sélectionner un type</option>
@@ -331,7 +335,7 @@ import { MarkdownComponent } from 'ngx-markdown';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class AcademicFormComponent implements OnInit, OnDestroy {
+export class AcademicFormComponent implements OnInit, OnDestroy, HasUnsavedChanges {
   academicForm!: FormGroup;
   isEditMode = false;
   isLoading = false;
@@ -418,6 +422,14 @@ export class AcademicFormComponent implements OnInit, OnDestroy {
   isFieldInvalid(fieldName: string): boolean {
     const field = this.academicForm.get(fieldName);
     return !!(field && field.invalid && (field.dirty || field.touched));
+  }
+
+  /**
+   * Returns true when the form has unsaved changes (dirty and not submitted).
+   * Used by canDeactivateGuard to warn before navigation.
+   */
+  hasUnsavedChanges(): boolean {
+    return this.academicForm?.dirty ?? false;
   }
 
   triggerImageUpload(): void {
@@ -507,6 +519,7 @@ export class AcademicFormComponent implements OnInit, OnDestroy {
         this.notificationService.success(
           this.isEditMode ? 'Travail académique mis à jour' : 'Travail académique créé'
         );
+        this.academicForm.markAsPristine();
         this.isSubmitting = false;
         this.router.navigate(['/academics', academic.id]);
       },

--- a/src/app/features/reviews/pages/review-form/review-form.component.ts
+++ b/src/app/features/reviews/pages/review-form/review-form.component.ts
@@ -7,6 +7,7 @@ import { NotificationService } from '@core/services/notification.service';
 import { ButtonComponent } from '@shared/components/button/button.component';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { StarRatingInputComponent } from '@shared/components/star-rating-input/star-rating-input.component';
+import { HasUnsavedChanges } from '@core/guards/can-deactivate.guard';
 import { Subject, takeUntil } from 'rxjs';
 
 /**
@@ -40,6 +41,7 @@ import { Subject, takeUntil } from 'rxjs';
               formControlName="title"
               placeholder="Saisir le titre de la critique"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              aria-required="true"
               [attr.aria-label]="'Titre de la critique'"
               [attr.aria-invalid]="isFieldInvalid('title')"
             />
@@ -55,6 +57,7 @@ import { Subject, takeUntil } from 'rxjs';
               formControlName="bookTitle"
               placeholder="Saisir le titre du livre"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              aria-required="true"
               [attr.aria-label]="'Titre du livre'"
               [attr.aria-invalid]="isFieldInvalid('bookTitle')"
             />
@@ -70,6 +73,7 @@ import { Subject, takeUntil } from 'rxjs';
               formControlName="bookAuthor"
               placeholder="Saisir le nom de l'auteur"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              aria-required="true"
               [attr.aria-label]="'Auteur du livre'"
               [attr.aria-invalid]="isFieldInvalid('bookAuthor')"
             />
@@ -83,6 +87,7 @@ import { Subject, takeUntil } from 'rxjs';
               id="genre"
               formControlName="genre"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              aria-required="true"
               [attr.aria-label]="'Genre'"
               [attr.aria-invalid]="isFieldInvalid('genre')"
             >
@@ -122,6 +127,7 @@ import { Subject, takeUntil } from 'rxjs';
               rows="3"
               maxlength="300"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)]"
+              aria-required="true"
               [attr.aria-label]="'Description'"
               [attr.aria-invalid]="isFieldInvalid('description')"
             ></textarea>
@@ -142,6 +148,7 @@ import { Subject, takeUntil } from 'rxjs';
               placeholder="Saisir le texte complet de la critique"
               rows="10"
               class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] text-sm"
+              aria-required="true"
               [attr.aria-label]="'Contenu de la critique'"
               [attr.aria-invalid]="isFieldInvalid('content')"
             ></textarea>
@@ -199,7 +206,7 @@ import { Subject, takeUntil } from 'rxjs';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class ReviewFormComponent implements OnInit, OnDestroy {
+export class ReviewFormComponent implements OnInit, OnDestroy, HasUnsavedChanges {
   reviewForm!: FormGroup;
   isEditMode = false;
   isLoading = false;
@@ -274,6 +281,14 @@ export class ReviewFormComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Returns true when the form has unsaved changes (dirty and not submitted).
+   * Used by canDeactivateGuard to warn before navigation.
+   */
+  hasUnsavedChanges(): boolean {
+    return this.reviewForm?.dirty ?? false;
+  }
+
+  /**
    * Check if form field is invalid and touched
    */
   isFieldInvalid(fieldName: string): boolean {
@@ -302,6 +317,7 @@ export class ReviewFormComponent implements OnInit, OnDestroy {
         this.notificationService.success(
           this.isEditMode ? 'Critique mise à jour avec succès' : 'Critique créée avec succès'
         );
+        this.reviewForm.markAsPristine();
         this.isSubmitting = false;
         this.router.navigate(['/reviews', review.id]);
       },

--- a/src/app/shared/components/notification/notification.component.ts
+++ b/src/app/shared/components/notification/notification.component.ts
@@ -35,10 +35,10 @@ import { NotificationService, Notification } from '@core/services/notification.s
         <div class="flex items-start gap-3">
           <!-- Icon -->
           <div class="text-xl mt-1">
-            <span *ngIf="notification.type === 'success'">✓</span>
-            <span *ngIf="notification.type === 'error'">✕</span>
-            <span *ngIf="notification.type === 'warning'">⚠</span>
-            <span *ngIf="notification.type === 'info'">ℹ</span>
+            <span *ngIf="notification.type === 'success'" aria-hidden="true">✓</span>
+            <span *ngIf="notification.type === 'error'" aria-hidden="true">✕</span>
+            <span *ngIf="notification.type === 'warning'" aria-hidden="true">⚠</span>
+            <span *ngIf="notification.type === 'info'" aria-hidden="true">ℹ</span>
           </div>
 
           <!-- Content -->
@@ -53,7 +53,7 @@ import { NotificationService, Notification } from '@core/services/notification.s
             class="text-lg font-bold opacity-70 hover:opacity-100 transition"
             [attr.aria-label]="'Fermer la notification'"
           >
-            ✕
+            <span aria-hidden="true">✕</span>
           </button>
         </div>
 


### PR DESCRIPTION
## Summary

Implements three accessibility and UX improvements in a single branch.

### #41 — canDeactivate guard on form routes
- Created `src/app/core/guards/can-deactivate.guard.ts` with `HasUnsavedChanges` interface and functional `canDeactivateGuard`
- `ReviewFormComponent` and `AcademicFormComponent` now implement `HasUnsavedChanges`
- Guard is registered on all 4 form routes (`reviews/new`, `reviews/:id/edit`, `academics/new`, `academics/:id/edit`)
- Forms call `markAsPristine()` after successful submission to avoid false warnings

### #45 — aria-required on mandatory form fields
- Added `aria-required="true"` to all required inputs in `ReviewFormComponent` (title, bookTitle, bookAuthor, genre, description, content)
- Added `aria-required="true"` to all required inputs in `AcademicFormComponent` (title, summary, workType)

### #46 — aria-hidden on decorative emojis in notifications
- Added `aria-hidden="true"` to the 4 icon spans (✓ ✕ ⚠ ℹ) in `NotificationComponent`
- Also applied to the ✕ inside the close button (the button already has `aria-label`)

## Validation
- ✅ `npm run lint` — all files pass linting
- ✅ `npm run test:ci` — 129/129 tests pass

Closes #41
Closes #45
Closes #46