### PR TITLE
fix(#42,#43): sanitize API error messages and add review deletion in admin

### DIFF
--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -3,10 +3,12 @@ import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { catchError, throwError } from 'rxjs';
 import { NotificationService } from '@core/services/notification.service';
+import { mapHttpError } from '@core/utils/http-error.utils';
 
 /**
  * HTTP Error Interceptor
- * Handles HTTP errors globally (no in-app login flow; auth is outside this UI).
+ * Handles HTTP errors globally with sanitized, user-friendly messages.
+ * Raw server error details (stack traces, SQL errors, etc.) are never exposed.
  */
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const router = inject(Router);
@@ -14,21 +16,24 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
+      const message = mapHttpError(error);
+
       switch (error.status) {
         case 401:
-          notifications.warning('Session expired — please sign in from the server portal.');
+          notifications.warning(message);
           router.navigate(['/401']);
           break;
         case 403:
-          notifications.warning('You do not have permission to perform this action.');
+          notifications.warning(message);
           break;
         case 404:
-          console.error('Resource not found');
+          // 404s are handled per-component; no global toast needed
           break;
-        case 500:
-          notifications.error('A server error occurred. Please try again later.');
+        default:
+          notifications.error(message);
           break;
       }
+
       return throwError(() => error);
     }),
   );

--- a/src/app/core/utils/http-error.utils.ts
+++ b/src/app/core/utils/http-error.utils.ts
@@ -14,6 +14,12 @@ export function mapHttpError(error: HttpErrorResponse): string {
       return 'Accès refusé.';
     case 404:
       return 'Ressource introuvable.';
+    case 422:
+      return 'Les données envoyées sont invalides.';
+    case 429:
+      return 'Trop de requêtes. Veuillez patienter.';
+    case 0:
+      return 'Impossible de joindre le serveur. Vérifiez votre connexion.';
     default:
       if (error.status >= 500) {
         return 'Une erreur serveur est survenue. Veuillez réessayer.';

--- a/src/app/core/utils/http-error.utils.ts
+++ b/src/app/core/utils/http-error.utils.ts
@@ -1,0 +1,23 @@
+import { HttpErrorResponse } from '@angular/common/http';
+
+/**
+ * Maps an HTTP error response to a user-friendly French message.
+ * Prevents leaking internal server details (stack traces, SQL errors, etc.).
+ */
+export function mapHttpError(error: HttpErrorResponse): string {
+  switch (error.status) {
+    case 400:
+      return 'Requête invalide.';
+    case 401:
+      return 'Vous devez être connecté.';
+    case 403:
+      return 'Accès refusé.';
+    case 404:
+      return 'Ressource introuvable.';
+    default:
+      if (error.status >= 500) {
+        return 'Une erreur serveur est survenue. Veuillez réessayer.';
+      }
+      return 'Une erreur inattendue est survenue.';
+  }
+}

--- a/src/app/features/admin/admin.routes.ts
+++ b/src/app/features/admin/admin.routes.ts
@@ -22,4 +22,11 @@ export const ADMIN_ROUTES: Routes = [
         (m) => m.AdminAcademicsComponent
       ),
   },
+  {
+    path: 'reviews',
+    loadComponent: () =>
+      import('./pages/admin-reviews/admin-reviews.component').then(
+        (m) => m.AdminReviewsComponent
+      ),
+  },
 ];

--- a/src/app/features/admin/pages/admin-dashboard/admin-dashboard.component.ts
+++ b/src/app/features/admin/pages/admin-dashboard/admin-dashboard.component.ts
@@ -47,6 +47,14 @@ import { RouterLink } from '@angular/router';
         </a>
 
         <a
+          routerLink="/admin/reviews"
+          class="rounded-lg border border-[var(--border-light)] bg-[var(--card-bg)] p-5 transition hover:border-[var(--accent-strong)]"
+        >
+          <h2 class="mb-1 font-semibold text-[var(--primary)]">Gérer les critiques</h2>
+          <p class="text-sm text-[var(--text-muted)]">Modifier ou supprimer des critiques.</p>
+        </a>
+
+        <a
           routerLink="/admin/academics"
           class="rounded-lg border border-[var(--border-light)] bg-[var(--card-bg)] p-5 transition hover:border-[var(--accent-strong)]"
         >

--- a/src/app/features/admin/pages/admin-reviews/admin-reviews.component.spec.ts
+++ b/src/app/features/admin/pages/admin-reviews/admin-reviews.component.spec.ts
@@ -1,0 +1,109 @@
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { of, throwError } from 'rxjs';
+import { AdminReviewsComponent } from './admin-reviews.component';
+import { ReviewService } from '@features/reviews/services/review.service';
+import { NotificationService } from '@core/services/notification.service';
+import { Review, ReviewPaginationResponse } from '@features/reviews/models/review.model';
+
+const mockReview: Review = {
+  id: 'r1',
+  title: 'Test Book',
+  author: 'Author',
+  bookTitle: 'Test Book',
+  bookAuthor: 'Book Author',
+  rating: 4,
+  genre: 'fiction',
+  description: 'Desc',
+  content: 'Content',
+  publishedAt: new Date(),
+  updatedAt: new Date(),
+  createdBy: 'u1',
+  isPublished: true,
+};
+
+const mockResponse: ReviewPaginationResponse = {
+  data: [mockReview],
+  total: 1,
+  page: 1,
+  limit: 100,
+  totalPages: 1,
+};
+
+describe('AdminReviewsComponent', () => {
+  let component: AdminReviewsComponent;
+  let fixture: ComponentFixture<AdminReviewsComponent>;
+  let reviewService: jasmine.SpyObj<ReviewService>;
+  let notificationService: jasmine.SpyObj<NotificationService>;
+  let router: Router;
+
+  beforeEach(async () => {
+    reviewService = jasmine.createSpyObj('ReviewService', ['getReviews', 'deleteReview']);
+    notificationService = jasmine.createSpyObj('NotificationService', ['success', 'error', 'warning']);
+
+    reviewService.getReviews.and.returnValue(of(mockResponse));
+    reviewService.deleteReview.and.returnValue(of(undefined));
+
+    await TestBed.configureTestingModule({
+      imports: [AdminReviewsComponent, RouterTestingModule],
+      providers: [
+        { provide: ReviewService, useValue: reviewService },
+        { provide: NotificationService, useValue: notificationService },
+      ],
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(AdminReviewsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should load reviews on init', () => {
+    expect(reviewService.getReviews).toHaveBeenCalled();
+    expect(component.reviews).toEqual([mockReview]);
+    expect(component.loading).toBeFalse();
+  });
+
+  it('should show error notification when loading fails', fakeAsync(() => {
+    reviewService.getReviews.and.returnValue(throwError(() => new Error('fail')));
+    component.loadReviews();
+    tick();
+    expect(notificationService.error).toHaveBeenCalledWith('Impossible de charger les critiques.');
+    expect(component.loading).toBeFalse();
+  }));
+
+  describe('deleteReview', () => {
+    it('should call deleteReview and show success when confirmed', fakeAsync(() => {
+      spyOn(window, 'confirm').and.returnValue(true);
+      const navigateSpy = spyOn(router, 'navigate').and.returnValue(Promise.resolve(true));
+
+      component.deleteReview(mockReview);
+      tick();
+
+      expect(reviewService.deleteReview).toHaveBeenCalledWith('r1');
+      expect(notificationService.success).toHaveBeenCalledWith('Critique supprimée.');
+      expect(navigateSpy).toHaveBeenCalledWith(['/admin/reviews']);
+    }));
+
+    it('should not call deleteReview when user cancels confirm', () => {
+      spyOn(window, 'confirm').and.returnValue(false);
+      component.deleteReview(mockReview);
+      expect(reviewService.deleteReview).not.toHaveBeenCalled();
+    });
+
+    it('should show error notification when deleteReview fails', fakeAsync(() => {
+      spyOn(window, 'confirm').and.returnValue(true);
+      reviewService.deleteReview.and.returnValue(throwError(() => new Error('fail')));
+
+      component.deleteReview(mockReview);
+      tick();
+
+      expect(notificationService.error).toHaveBeenCalledWith('Impossible de supprimer la critique.');
+    }));
+  });
+});

--- a/src/app/features/admin/pages/admin-reviews/admin-reviews.component.ts
+++ b/src/app/features/admin/pages/admin-reviews/admin-reviews.component.ts
@@ -1,0 +1,142 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router, RouterLink } from '@angular/router';
+import { ReviewService } from '@features/reviews/services/review.service';
+import { NotificationService } from '@core/services/notification.service';
+import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
+import { Subject, takeUntil } from 'rxjs';
+import { Review, ReviewPaginationResponse } from '@features/reviews/models/review.model';
+
+/**
+ * Admin Reviews Component
+ * Lists all reviews with edit and delete actions (admin-only view).
+ * Delete requires window.confirm confirmation before calling the API.
+ */
+@Component({
+  selector: 'app-admin-reviews',
+  standalone: true,
+  imports: [CommonModule, RouterLink, LoadingSpinnerComponent],
+  template: `
+    <div class="page-container page-container--tight-y">
+      <div class="mb-8">
+        <a routerLink="/admin" class="text-[var(--accent-strong)] hover:text-[var(--primary)] mb-2 inline-block font-semibold">← Retour au tableau de bord</a>
+        <h1 class="text-4xl font-bold text-[var(--primary)]">Critiques</h1>
+        <p class="text-[var(--text-muted)] mt-1">Gérer toutes les critiques de livres.</p>
+      </div>
+
+      <div class="mb-4">
+        <a
+          routerLink="/reviews/new"
+          class="inline-block px-4 py-2 rounded-lg bg-[var(--accent-strong)] text-white font-semibold hover:brightness-90 transition"
+        >+ Nouvelle critique</a>
+      </div>
+
+      <app-loading-spinner *ngIf="loading"></app-loading-spinner>
+
+      <div *ngIf="!loading" class="space-y-4">
+        <div
+          *ngFor="let review of reviews; trackBy: trackById"
+          class="bg-[var(--card-bg)] rounded-lg border border-[var(--border-light)] p-6"
+        >
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <h2 class="text-xl font-semibold text-[var(--primary)]">{{ review.title }}</h2>
+              <p class="text-sm text-[var(--text-muted)]">{{ review.bookTitle }} · {{ review.bookAuthor }} · ★ {{ review.rating }}/5</p>
+              <p class="text-sm text-[var(--text-dark)] mt-1 line-clamp-2">{{ review.description }}</p>
+              <span
+                class="mt-2 inline-block text-xs font-semibold px-2 py-0.5 rounded-full"
+                [class.bg-green-100]="review.isPublished"
+                [class.text-green-700]="review.isPublished"
+                [class.bg-yellow-100]="!review.isPublished"
+                [class.text-yellow-700]="!review.isPublished"
+              >{{ review.isPublished ? 'Publié' : 'Non publié' }}</span>
+            </div>
+            <div class="flex gap-2 flex-shrink-0">
+              <a
+                [routerLink]="['/reviews', review.id, 'edit']"
+                class="px-4 py-2 bg-[var(--surface-alt)] text-[var(--primary)] rounded font-medium hover:brightness-95 transition inline-block"
+                [attr.aria-label]="'Modifier ' + review.title"
+              >Modifier</a>
+              <button
+                type="button"
+                (click)="deleteReview(review)"
+                class="px-4 py-2 bg-red-600 text-white rounded font-medium hover:bg-red-700 transition"
+                [attr.aria-label]="'Supprimer ' + review.title"
+              >Supprimer</button>
+            </div>
+          </div>
+        </div>
+        <p *ngIf="reviews.length === 0" class="text-center text-[var(--text-muted)] py-8">Aucune critique trouvée.</p>
+      </div>
+    </div>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class AdminReviewsComponent implements OnInit, OnDestroy {
+  reviews: Review[] = [];
+  loading = true;
+  private destroy$ = new Subject<void>();
+
+  constructor(
+    private reviewService: ReviewService,
+    private notificationService: NotificationService,
+    private router: Router,
+    private cdr: ChangeDetectorRef
+  ) {}
+
+  ngOnInit(): void {
+    this.loadReviews();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  loadReviews(): void {
+    this.loading = true;
+    this.reviewService
+      .getReviews({ limit: 100 })
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (res: ReviewPaginationResponse) => {
+          this.reviews = res.data || [];
+          this.loading = false;
+          this.cdr.markForCheck();
+        },
+        error: () => {
+          this.notificationService.error('Impossible de charger les critiques.');
+          this.loading = false;
+          this.cdr.markForCheck();
+        },
+      });
+  }
+
+  deleteReview(review: Review): void {
+    if (!confirm(`Supprimer la critique "${review.title}" ?`)) return;
+
+    this.reviewService
+      .deleteReview(review.id)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: () => {
+          this.notificationService.success('Critique supprimée.');
+          this.router.navigate(['/admin/reviews']);
+          this.loadReviews();
+        },
+        error: () => {
+          this.notificationService.error('Impossible de supprimer la critique.');
+        },
+      });
+  }
+
+  trackById(_index: number, review: Review): string {
+    return review.id;
+  }
+}

--- a/src/app/features/reviews/pages/review-list/review-list.component.ts
+++ b/src/app/features/reviews/pages/review-list/review-list.component.ts
@@ -94,9 +94,8 @@ import { debounceTime } from 'rxjs/operators';
       </div>
 
       <!-- Error State -->
-      <div *ngIf="error$ | async as error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-6" role="alert">
+      <div *ngIf="error$ | async" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-6" role="alert">
         <p class="font-bold mb-2">Erreur lors du chargement des critiques. Veuillez réessayer.</p>
-        <p class="text-sm mb-3">{{ error }}</p>
         <button (click)="retryLoadReviews()" class="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700">
           Réessayer
         </button>
@@ -227,8 +226,8 @@ export class ReviewListComponent implements OnInit, OnDestroy {
           this.totalItems = res.total;
           this.totalPages = res.totalPages || Math.ceil(res.total / this.pageSize) || 1;
         },
-        error: (error) => {
-          this.error$.next(error?.message || 'Erreur réseau ou serveur indisponible');
+        error: () => {
+          this.error$.next('Erreur réseau ou serveur indisponible. Veuillez réessayer.');
         },
       });
   }


### PR DESCRIPTION
## Summary

Resolves #42 — Sanitize API error messages to prevent info leaks and improve UX.
Resolves #43 — Add review deletion to the admin panel.

## Changes

### Issue #42 — Error message sanitization
- **New utility** `src/app/core/utils/http-error.utils.ts`: `mapHttpError()` maps `HttpErrorResponse` → safe French strings (400, 401, 403, 404, 5xx, default) with no server internals exposed
- **Updated error interceptor**: uses `mapHttpError`, adds missing 400 and default cases, all messages now in French, removed bare `console.error` on 404
- **Fixed review-list component**: removed `{{ error }}` interpolation from template and `error?.message` binding that leaked raw API error text to the user

### Issue #43 — Admin review deletion
- **New `AdminReviewsComponent`** (`/admin/reviews`): standalone, `OnPush`, lists all reviews with Modifier / Supprimer buttons; delete requires `window.confirm` and shows success/error via `NotificationService`
- **New route** `/admin/reviews` registered in `admin.routes.ts` (lazy-loaded)
- **Admin dashboard card** added linking to `/admin/reviews`
- **Unit tests** covering: component creation, list load, load error, delete confirmed, delete cancelled, delete error (6 new tests → 135 total, all pass)

## Validation
- `npm run lint` → ✅ All files pass
- `npm run test:ci` → ✅ 135/135 pass