### PR TITLE
feat(#47): scroll-to-top automatique lors du changement de page

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,7 +1,7 @@
 import { APP_INITIALIZER, ApplicationConfig } from '@angular/core';
 import { APP_BASE_HREF, registerLocaleData } from '@angular/common';
 import localeFr from '@angular/common/locales/fr';
-import { provideRouter } from '@angular/router';
+import { provideRouter, withInMemoryScrolling } from '@angular/router';
 
 registerLocaleData(localeFr);
 import { provideHttpClient, withInterceptors } from '@angular/common/http';
@@ -20,7 +20,7 @@ function appBaseHrefFactory(): string {
 export const appConfig: ApplicationConfig = {
   providers: [
     { provide: APP_BASE_HREF, useFactory: appBaseHrefFactory },
-    provideRouter(routes),
+    provideRouter(routes, withInMemoryScrolling({ scrollPositionRestoration: 'top', anchorScrolling: 'enabled' })),
     provideHttpClient(withInterceptors([errorInterceptor])),
     provideAnimations(),
     provideMarkdown(),


### PR DESCRIPTION
## Summary

Fixes the UX issue where navigating to a new page via pagination left the viewport scrolled to the bottom of the previous page content.

## Changes

- **`src/app/app.config.ts`**: Added `withInMemoryScrolling` feature to `provideRouter`
  - `scrollPositionRestoration: 'top'` — scrolls to the top of the page on every navigation
  - `anchorScrolling: 'enabled'` — preserves support for anchor (`#fragment`) links

## Why

When a user clicked a pagination control, the browser kept the scroll position from the previous page. With this change, Angular's Router automatically scrolls to the top after each navigation event, ensuring users always see the top of the new page content.

closes #47