### PR TITLE
feat(#54): modale de confirmation réutilisable remplaçant window.confirm

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,13 +3,15 @@ import { RouterOutlet } from '@angular/router';
 import { HeaderComponent } from './shared/components/header/header.component';
 import { FooterComponent } from './shared/components/footer/footer.component';
 import { NotificationComponent } from './shared/components/notification/notification.component';
+import { ConfirmDialogComponent } from './shared/components/confirm-dialog/confirm-dialog.component';
 
 @Component({
   selector: 'app-root',
   standalone: true,
-  imports: [RouterOutlet, HeaderComponent, FooterComponent, NotificationComponent],
+  imports: [RouterOutlet, HeaderComponent, FooterComponent, NotificationComponent, ConfirmDialogComponent],
   template: `
     <app-notification></app-notification>
+    <app-confirm-dialog></app-confirm-dialog>
     <app-header></app-header>
     <main id="main-content" class="min-h-screen" role="main">
       <router-outlet></router-outlet>

--- a/src/app/features/admin/pages/admin-academics/admin-academics.component.ts
+++ b/src/app/features/admin/pages/admin-academics/admin-academics.component.ts
@@ -9,6 +9,7 @@ import { CommonModule } from '@angular/common';
 import { RouterLink } from '@angular/router';
 import { AcademicService } from '../../../academics/services/academic.service';
 import { NotificationService } from '@core/services/notification.service';
+import { ConfirmService } from '@shared/services/confirm.service';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { Subject, takeUntil } from 'rxjs';
 import { AcademicWork } from '../../../academics/models/academic.model';
@@ -92,6 +93,7 @@ export class AdminAcademicsComponent implements OnInit, OnDestroy {
   constructor(
     private academicService: AcademicService,
     private notificationService: NotificationService,
+    private confirmService: ConfirmService,
     private cdr: ChangeDetectorRef
   ) {}
 
@@ -139,17 +141,19 @@ export class AdminAcademicsComponent implements OnInit, OnDestroy {
   }
 
   deleteAcademic(academic: AcademicWork): void {
-    if (!confirm(`Supprimer "${academic.title}" ?`)) return;
-    this.academicService
-      .deleteAcademic(academic.id)
-      .pipe(takeUntil(this.destroy$))
-      .subscribe({
-        next: () => {
-          this.notificationService.success('Travail académique supprimé.');
-          this.loadAcademics();
-        },
-        error: () => this.notificationService.error('Impossible de supprimer le travail.'),
-      });
+    this.confirmService.confirm(`Supprimer "${academic.title}" ?`).then((confirmed) => {
+      if (!confirmed) return;
+      this.academicService
+        .deleteAcademic(academic.id)
+        .pipe(takeUntil(this.destroy$))
+        .subscribe({
+          next: () => {
+            this.notificationService.success('Travail académique supprimé.');
+            this.loadAcademics();
+          },
+          error: () => this.notificationService.error('Impossible de supprimer le travail.'),
+        });
+    });
   }
 
   trackById(_index: number, academic: AcademicWork): string {

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,100 @@
+import {
+  Component,
+  OnInit,
+  OnDestroy,
+  ChangeDetectionStrategy,
+  signal,
+  HostListener,
+} from '@angular/core';
+import { ConfirmService, ConfirmRequest } from '@shared/services/confirm.service';
+import { Subscription } from 'rxjs';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  standalone: true,
+  imports: [],
+  template: `
+    @if (pending()) {
+      <div
+        class="fixed inset-0 z-[9999] flex items-center justify-center"
+        role="dialog"
+        aria-modal="true"
+        [attr.aria-labelledby]="'confirm-dialog-title'"
+      >
+        <!-- Backdrop -->
+        <div
+          class="absolute inset-0 bg-black/50 backdrop-blur-sm"
+          (click)="cancel()"
+          aria-hidden="true"
+        ></div>
+
+        <!-- Dialog panel -->
+        <div
+          class="relative z-10 bg-[var(--surface,#fff)] border border-[var(--border-light,#e2d9e9)] rounded-2xl shadow-xl p-8 max-w-sm w-full mx-4"
+          cdkTrapFocus
+        >
+          <h2
+            id="confirm-dialog-title"
+            class="text-xl font-bold text-[var(--primary)] mb-4"
+          >Confirmation</h2>
+
+          <p class="text-[var(--text-dark)] mb-6">{{ pending()!.message }}</p>
+
+          <div class="flex gap-3 justify-end">
+            <button
+              type="button"
+              (click)="cancel()"
+              class="px-5 py-2 rounded-lg border border-[var(--border-light)] bg-[var(--surface-alt,#f9f5fb)] text-[var(--text-dark)] font-semibold hover:brightness-95 transition focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:ring-offset-2"
+            >Annuler</button>
+            <button
+              type="button"
+              (click)="confirm()"
+              class="px-5 py-2 rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
+              cdkFocusInitial
+            >Confirmer</button>
+          </div>
+        </div>
+      </div>
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ConfirmDialogComponent implements OnInit, OnDestroy {
+  protected readonly pending = signal<ConfirmRequest | null>(null);
+  private subscription?: Subscription;
+
+  constructor(private confirmService: ConfirmService) {}
+
+  ngOnInit(): void {
+    this.subscription = this.confirmService.confirmation$.subscribe((request) => {
+      this.pending.set(request);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.subscription?.unsubscribe();
+  }
+
+  @HostListener('document:keydown.escape')
+  onEscape(): void {
+    if (this.pending()) {
+      this.cancel();
+    }
+  }
+
+  protected confirm(): void {
+    const current = this.pending();
+    if (current) {
+      this.pending.set(null);
+      current.resolve(true);
+    }
+  }
+
+  protected cancel(): void {
+    const current = this.pending();
+    if (current) {
+      this.pending.set(null);
+      current.resolve(false);
+    }
+  }
+}

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -6,6 +6,10 @@ import {
   signal,
   HostListener,
   ElementRef,
+  ViewChild,
+  effect,
+  afterNextRender,
+  Injector,
 } from '@angular/core';
 import { ConfirmService, ConfirmRequest } from '@shared/services/confirm.service';
 import { Subscription } from 'rxjs';
@@ -47,6 +51,7 @@ import { Subscription } from 'rxjs';
               class="px-5 py-2 rounded-lg border border-[var(--border-light)] bg-[var(--surface-alt,#f9f5fb)] text-[var(--text-dark)] font-semibold hover:brightness-95 transition focus:outline-none focus:ring-2 focus:ring-[var(--primary)] focus:ring-offset-2"
             >Annuler</button>
             <button
+              #confirmBtn
               type="button"
               (click)="confirm()"
               class="px-5 py-2 rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
@@ -62,10 +67,22 @@ export class ConfirmDialogComponent implements OnInit, OnDestroy {
   protected readonly pending = signal<ConfirmRequest | null>(null);
   private subscription?: Subscription;
 
+  @ViewChild('confirmBtn') confirmBtn?: ElementRef<HTMLButtonElement>;
+
   constructor(
     private confirmService: ConfirmService,
     private el: ElementRef<HTMLElement>,
-  ) {}
+    private injector: Injector,
+  ) {
+    // Bug A fix: auto-focus the confirm button each time the dialog opens
+    effect(() => {
+      if (this.pending()) {
+        afterNextRender(() => {
+          this.confirmBtn?.nativeElement?.focus();
+        }, { injector: this.injector });
+      }
+    });
+  }
 
   ngOnInit(): void {
     this.subscription = this.confirmService.confirmation$.subscribe((request) => {
@@ -84,6 +101,8 @@ export class ConfirmDialogComponent implements OnInit, OnDestroy {
     const focusable = this.el.nativeElement.querySelectorAll<HTMLElement>(
       'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
     );
+    // Bug B fix: guard against empty focusable list to prevent TypeError
+    if (!focusable.length) return;
     const first = focusable[0];
     const last = focusable[focusable.length - 1];
     if (e.shiftKey ? document.activeElement === first : document.activeElement === last) {

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -5,6 +5,7 @@ import {
   ChangeDetectionStrategy,
   signal,
   HostListener,
+  ElementRef,
 } from '@angular/core';
 import { ConfirmService, ConfirmRequest } from '@shared/services/confirm.service';
 import { Subscription } from 'rxjs';
@@ -19,7 +20,7 @@ import { Subscription } from 'rxjs';
         class="fixed inset-0 z-[9999] flex items-center justify-center"
         role="dialog"
         aria-modal="true"
-        [attr.aria-labelledby]="'confirm-dialog-title'"
+        aria-labelledby="confirm-dialog-title"
       >
         <!-- Backdrop -->
         <div
@@ -31,7 +32,6 @@ import { Subscription } from 'rxjs';
         <!-- Dialog panel -->
         <div
           class="relative z-10 bg-[var(--surface,#fff)] border border-[var(--border-light,#e2d9e9)] rounded-2xl shadow-xl p-8 max-w-sm w-full mx-4"
-          cdkTrapFocus
         >
           <h2
             id="confirm-dialog-title"
@@ -50,7 +50,6 @@ import { Subscription } from 'rxjs';
               type="button"
               (click)="confirm()"
               class="px-5 py-2 rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
-              cdkFocusInitial
             >Confirmer</button>
           </div>
         </div>
@@ -63,7 +62,10 @@ export class ConfirmDialogComponent implements OnInit, OnDestroy {
   protected readonly pending = signal<ConfirmRequest | null>(null);
   private subscription?: Subscription;
 
-  constructor(private confirmService: ConfirmService) {}
+  constructor(
+    private confirmService: ConfirmService,
+    private el: ElementRef<HTMLElement>,
+  ) {}
 
   ngOnInit(): void {
     this.subscription = this.confirmService.confirmation$.subscribe((request) => {
@@ -75,10 +77,18 @@ export class ConfirmDialogComponent implements OnInit, OnDestroy {
     this.subscription?.unsubscribe();
   }
 
-  @HostListener('document:keydown.escape')
-  onEscape(): void {
-    if (this.pending()) {
-      this.cancel();
+  @HostListener('keydown', ['$event'])
+  onKeydown(e: KeyboardEvent): void {
+    if (e.key === 'Escape') { this.cancel(); return; }
+    if (e.key !== 'Tab') return;
+    const focusable = this.el.nativeElement.querySelectorAll<HTMLElement>(
+      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+    );
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (e.shiftKey ? document.activeElement === first : document.activeElement === last) {
+      e.preventDefault();
+      (e.shiftKey ? last : first).focus();
     }
   }
 

--- a/src/app/shared/services/confirm.service.ts
+++ b/src/app/shared/services/confirm.service.ts
@@ -10,10 +10,19 @@ export interface ConfirmRequest {
 export class ConfirmService {
   private subject = new Subject<ConfirmRequest>();
   readonly confirmation$ = this.subject.asObservable();
+  private _resolve: ((v: boolean) => void) | null = null;
 
   confirm(message: string): Promise<boolean> {
-    return new Promise((resolve) => {
-      this.subject.next({ message, resolve });
+    if (this._resolve) { this._resolve(false); }
+    return new Promise<boolean>(resolve => {
+      this._resolve = resolve;
+      this.subject.next({
+        message,
+        resolve: (result: boolean) => {
+          this._resolve = null;
+          resolve(result);
+        },
+      });
     });
   }
 }

--- a/src/app/shared/services/confirm.service.ts
+++ b/src/app/shared/services/confirm.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@angular/core';
+import { Subject } from 'rxjs';
+
+export interface ConfirmRequest {
+  message: string;
+  resolve: (result: boolean) => void;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ConfirmService {
+  private subject = new Subject<ConfirmRequest>();
+  readonly confirmation$ = this.subject.asObservable();
+
+  confirm(message: string): Promise<boolean> {
+    return new Promise((resolve) => {
+      this.subject.next({ message, resolve });
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Closes #54

Replace the inaccessible `confirm()` / `window.confirm()` native browser dialog with a proper, accessible Angular modal.

## Changes

### New files
- **`src/app/shared/services/confirm.service.ts`** — `ConfirmService` (providedIn root). Exposes `confirm(message): Promise<boolean>` backed by an RxJS `Subject<ConfirmRequest>`.
- **`src/app/shared/components/confirm-dialog/confirm-dialog.component.ts`** — `ConfirmDialogComponent`. Standalone, `OnPush`, `signal()` state. Accessible: `role="dialog"`, `aria-modal="true"`, Escape key cancels via `@HostListener`.

### Modified files
- **`src/app/app.component.ts`** — registers `ConfirmDialogComponent` in the app shell so it is always present.
- **`src/app/features/admin/pages/admin-academics/admin-academics.component.ts`** — replaces `confirm()` call with `this.confirmService.confirm(msg).then(...)`.

## Validation
- All changes validated via CI (lint + unit tests + build)