### PR TITLE
feat(#52): transition CSS slide-in sur le menu mobile

### DIFF
--- a/src/app/shared/components/header/header.component.spec.ts
+++ b/src/app/shared/components/header/header.component.spec.ts
@@ -49,14 +49,22 @@ describe('HeaderComponent', () => {
     const toggle = el.querySelector('#mobile-nav-toggle') as HTMLButtonElement | null;
     expect(toggle).toBeTruthy();
     expect(toggle!.getAttribute('aria-expanded')).toBe('false');
+
+    // Panel is always in the DOM (CSS slide-in transition), hidden when closed
+    const panel = el.querySelector('#mobile-nav-panel');
+    expect(panel).toBeTruthy();
+    expect(panel!.getAttribute('aria-hidden')).toBe('true');
+
     toggle!.click();
     fixture.detectChanges();
     expect(toggle!.getAttribute('aria-expanded')).toBe('true');
-    const panel = el.querySelector('#mobile-nav-panel');
-    expect(panel).toBeTruthy();
+    expect(panel!.getAttribute('aria-hidden')).toBeNull();
+
     toggle!.click();
     fixture.detectChanges();
     expect(toggle!.getAttribute('aria-expanded')).toBe('false');
-    expect(el.querySelector('#mobile-nav-panel')).toBeFalsy();
+    // Panel stays in DOM but is marked aria-hidden when closed
+    expect(el.querySelector('#mobile-nav-panel')).toBeTruthy();
+    expect(panel!.getAttribute('aria-hidden')).toBe('true');
   });
 });

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -43,6 +43,12 @@ import { filter, Subject, takeUntil } from 'rxjs';
         opacity: 1;
         pointer-events: auto;
       }
+      @media (prefers-reduced-motion: reduce) {
+        .nav-mobile-panel,
+        .nav-mobile-backdrop {
+          transition: none;
+        }
+      }
     `,
   ],
   template: `

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -19,6 +19,32 @@ import { filter, Subject, takeUntil } from 'rxjs';
   selector: 'app-header',
   standalone: true,
   imports: [RouterLink],
+  styles: [
+    `
+      .nav-mobile-panel {
+        transform: translateX(-100%);
+        transition:
+          transform 0.25s ease-in-out,
+          opacity 0.25s ease-in-out;
+        opacity: 0;
+        pointer-events: none;
+      }
+      .nav-mobile-panel.is-open {
+        transform: translateX(0);
+        opacity: 1;
+        pointer-events: auto;
+      }
+      .nav-mobile-backdrop {
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.2s ease-in-out;
+      }
+      .nav-mobile-backdrop.is-open {
+        opacity: 1;
+        pointer-events: auto;
+      }
+    `,
+  ],
   template: `
     <header
       class="relative sticky top-0 z-40 border-b border-[var(--border-light)] shadow-sm bg-[color:var(--header-bg)] backdrop-blur-md"
@@ -84,72 +110,77 @@ import { filter, Subject, takeUntil } from 'rxjs';
         </div>
       </nav>
 
-      @if (mobileNavOpen()) {
-        <div
-          class="fixed inset-0 z-[45] bg-black/35 md:hidden"
-          aria-hidden="true"
-          (click)="closeMobileNav()"
-        ></div>
-        <div
-          #mobileNavPanel
-          id="mobile-nav-panel"
-          class="fixed left-4 right-4 top-[4.25rem] z-50 max-h-[min(70vh,calc(100dvh-6rem))] overflow-y-auto rounded-lg border border-[var(--border-light)] bg-[var(--card-bg)] p-4 shadow-lg md:hidden"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Menu mobile"
-        >
-          <ul class="flex flex-col gap-1">
-            <li>
-              <a
-                routerLink="/"
-                class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
-                (click)="closeMobileNav()"
-                >Accueil</a
-              >
-            </li>
-            <li>
-              <a
-                routerLink="/reviews"
-                class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
-                (click)="closeMobileNav()"
-                >Critiques</a
-              >
-            </li>
-            <li>
-              <a
-                routerLink="/academics"
-                class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
-                (click)="closeMobileNav()"
-                >Travaux</a
-              >
-            </li>
-            <li>
-              <a
-                routerLink="/about"
-                class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
-                (click)="closeMobileNav()"
-                >À propos</a
-              >
-            </li>
-            <li>
-              <a
-                routerLink="/contact"
-                class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
-                (click)="closeMobileNav()"
-                >Contact</a
-              >
-            </li>
-            <li>
-              <a
-                routerLink="/admin"
-                class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
-                (click)="closeMobileNav()"
-                >Admin</a
-              >
-            </li>
-          </ul>
-        </div>
-      }
+      <!-- Backdrop: always in DOM, fades in/out via .is-open -->
+      <div
+        class="nav-mobile-backdrop fixed inset-0 z-[45] bg-black/35 md:hidden"
+        [class.is-open]="mobileNavOpen()"
+        aria-hidden="true"
+        (click)="closeMobileNav()"
+      ></div>
+
+      <!-- Panel: always in DOM, slides in from left via .is-open -->
+      <div
+        #mobileNavPanel
+        id="mobile-nav-panel"
+        class="nav-mobile-panel fixed left-4 right-4 top-[4.25rem] z-50 max-h-[min(70vh,calc(100dvh-6rem))] overflow-y-auto rounded-lg border border-[var(--border-light)] bg-[var(--card-bg)] p-4 shadow-lg md:hidden"
+        [class.is-open]="mobileNavOpen()"
+        [attr.aria-hidden]="!mobileNavOpen() ? 'true' : null"
+        [attr.inert]="!mobileNavOpen() ? '' : null"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menu mobile"
+      >
+        <ul class="flex flex-col gap-1">
+          <li>
+            <a
+              routerLink="/"
+              class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
+              (click)="closeMobileNav()"
+              >Accueil</a
+            >
+          </li>
+          <li>
+            <a
+              routerLink="/reviews"
+              class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
+              (click)="closeMobileNav()"
+              >Critiques</a
+            >
+          </li>
+          <li>
+            <a
+              routerLink="/academics"
+              class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
+              (click)="closeMobileNav()"
+              >Travaux</a
+            >
+          </li>
+          <li>
+            <a
+              routerLink="/about"
+              class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
+              (click)="closeMobileNav()"
+              >À propos</a
+            >
+          </li>
+          <li>
+            <a
+              routerLink="/contact"
+              class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
+              (click)="closeMobileNav()"
+              >Contact</a
+            >
+          </li>
+          <li>
+            <a
+              routerLink="/admin"
+              class="block rounded-md px-3 py-3 font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
+              (click)="closeMobileNav()"
+              >Admin</a
+            >
+          </li>
+        </ul>
+      </div>
     </header>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary

Implements smooth slide-in/out CSS transition for the mobile navigation panel (closes #52).

## Changes

- **CSS transitions**: Added `.nav-mobile-panel` (slide from left, `translateX(-100%) → translateX(0)`) and `.nav-mobile-backdrop` (fade, `opacity 0 → 1`) with 0.25s ease-in-out
- **Always in DOM**: Replaced `@if(mobileNavOpen())` with always-present elements; open/close state driven by `[class.is-open]="mobileNavOpen()"`  
- **Accessibility preserved**: `[attr.inert]` prevents keyboard focus when panel is hidden; `[attr.aria-hidden]` hides it from screen readers; `aria-expanded`, Escape key, and focus-trap logic unchanged
- **Spec updated**: Test now asserts `aria-hidden` attribute instead of element presence/absence

## Behaviour

| State | Panel transform | Backdrop opacity | `aria-hidden` | `inert` |
|-------|----------------|-----------------|----------------|--------|
| Closed | `translateX(-100%)` | 0 | `true` | present |
| Open   | `translateX(0)` | 1 | — | — |

## Validation

- CI lint + unit tests (spec updated to match new DOM-always-present behaviour)