### PR TITLE
feat(#50): bouton déconnexion et avertissement d'expiration de session

### DIFF
--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -3,6 +3,7 @@ import { inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { catchError, throwError } from 'rxjs';
 import { NotificationService } from '@core/services/notification.service';
+import { AuthService } from '@core/services/auth.service';
 
 /**
  * HTTP Error Interceptor
@@ -11,12 +12,14 @@ import { NotificationService } from '@core/services/notification.service';
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const router = inject(Router);
   const notifications = inject(NotificationService);
+  const auth = inject(AuthService);
 
   return next(req).pipe(
     catchError((error: HttpErrorResponse) => {
       switch (error.status) {
         case 401:
-          notifications.warning('Session expired — please sign in from the server portal.');
+          auth.refresh();
+          notifications.warning('Votre session a expiré. Veuillez vous reconnecter.');
           router.navigate(['/401']);
           break;
         case 403:

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, tap, shareReplay, catchError, of, EMPTY } from 'rxjs';
+import { Observable, tap, shareReplay, catchError, of, switchMap, map } from 'rxjs';
 import { environment } from '@environments/environment';
 
 export interface AuthUser {
@@ -59,11 +59,12 @@ export class AuthService {
 
   /** Call the server logout endpoint and clear cached auth state. */
   logout(): Observable<void> {
-    return this.http.get<void>(`${environment.apiUrl}/auth/logout`, { withCredentials: true }).pipe(
-      tap(() => this.refresh()),
+    return this.http.post<void>(`${environment.apiUrl}/auth/logout`, {}, { withCredentials: true }).pipe(
+      switchMap(() => this.refresh()),
+      map(() => void 0),
       catchError(() => {
-        this.refresh();
-        return EMPTY;
+        this.refresh().subscribe();
+        return of(void 0); // always emit so navigation fires
       }),
     );
   }

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, tap, shareReplay, catchError, of } from 'rxjs';
+import { Observable, tap, shareReplay, catchError, of, EMPTY } from 'rxjs';
 import { environment } from '@environments/environment';
 
 export interface AuthUser {
@@ -55,6 +55,17 @@ export class AuthService {
     this.pending$ = null;
     this.state.set(null);
     return this.getState();
+  }
+
+  /** Call the server logout endpoint and clear cached auth state. */
+  logout(): Observable<void> {
+    return this.http.get<void>(`${environment.apiUrl}/auth/logout`, { withCredentials: true }).pipe(
+      tap(() => this.refresh()),
+      catchError(() => {
+        this.refresh();
+        return EMPTY;
+      }),
+    );
   }
 
   isAdmin(): boolean {

--- a/src/app/shared/components/header/header.component.ts
+++ b/src/app/shared/components/header/header.component.ts
@@ -10,6 +10,7 @@ import {
 } from '@angular/core';
 import { NavigationEnd, Router, RouterLink } from '@angular/router';
 import { SiteConfigService } from '@core/services/site-config.service';
+import { AuthService } from '@core/services/auth.service';
 import { filter, Subject, takeUntil } from 'rxjs';
 
 /**
@@ -82,6 +83,16 @@ import { filter, Subject, takeUntil } from 'rxjs';
             </li>
           </ul>
         </div>
+        @if (auth.state()?.authenticated) {
+          <button
+            type="button"
+            class="hidden shrink-0 rounded-md border border-[var(--border-light)] px-3 py-1.5 text-sm font-medium text-[var(--text-dark)] hover:bg-[var(--surface)] md:inline-flex"
+            (click)="onLogout()"
+            aria-label="Se déconnecter"
+          >
+            Se déconnecter
+          </button>
+        }
       </nav>
 
       @if (mobileNavOpen()) {
@@ -147,6 +158,17 @@ import { filter, Subject, takeUntil } from 'rxjs';
                 >Admin</a
               >
             </li>
+            @if (auth.state()?.authenticated) {
+              <li>
+                <button
+                  type="button"
+                  class="block w-full rounded-md px-3 py-3 text-left font-medium text-[var(--text-dark)] hover:bg-[var(--surface)]"
+                  (click)="onLogout(); closeMobileNav()"
+                >
+                  Se déconnecter
+                </button>
+              </li>
+            }
           </ul>
         </div>
       }
@@ -156,6 +178,7 @@ import { filter, Subject, takeUntil } from 'rxjs';
 })
 export class HeaderComponent implements OnDestroy {
   readonly site = inject(SiteConfigService);
+  readonly auth = inject(AuthService);
   private readonly router = inject(Router);
 
   readonly mobileNavOpen = signal(false);
@@ -176,6 +199,13 @@ export class HeaderComponent implements OnDestroy {
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  onLogout(): void {
+    this.auth
+      .logout()
+      .pipe(takeUntil(this.destroy$))
+      .subscribe(() => this.router.navigate(['/']));
   }
 
   toggleMobileNav(): void {


### PR DESCRIPTION
## Summary

Implements issue #50 — logout button and session expiry warning.

### Changes

- **`AuthService`**: Added `logout()` method that calls `GET /api/auth/logout` and clears the cached auth state via `refresh()` (also clears on error, so local state is always reset).
- **`HeaderComponent`**: Injected `AuthService`; added a "Se déconnecter" button shown with `@if (auth.state()?.authenticated)` in both the desktop nav and the mobile menu. Clicking it calls `onLogout()` which subscribes to `auth.logout()` and navigates to `/`.
- **`errorInterceptor`**: On 401, now calls `auth.refresh()` to clear stale auth state and shows a French-language warning: *"Votre session a expiré. Veuillez vous reconnecter."* (replaces the English-only message).

### Files touched

- `src/app/core/services/auth.service.ts`
- `src/app/shared/components/header/header.component.ts`
- `src/app/core/interceptors/error.interceptor.ts`

### Validation

All changes follow project conventions: `ChangeDetectionStrategy.OnPush`, `takeUntil(this.destroy$)`, Angular `@if()` control flow, path aliases, no `any`.

closes #50