### PR TITLE
feat(#49,#55): garde de concurrence sur le refresh token + retry HTTP automatique

### DIFF
--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -1,24 +1,67 @@
 import { HttpInterceptorFn, HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { Router } from '@angular/router';
-import { catchError, throwError } from 'rxjs';
+import { catchError, filter, retry, switchMap, take, throwError, timer } from 'rxjs';
 import { NotificationService } from '@core/services/notification.service';
+import { AuthService } from '@core/services/auth.service';
+
+const RETRYABLE_STATUS_CODES = [429, 502, 503];
+const MAX_RETRY_COUNT = 3;
 
 /**
  * HTTP Error Interceptor
- * Handles HTTP errors globally (no in-app login flow; auth is outside this UI).
+ * - 429 / 502 / 503: retries up to 3× with exponential backoff (H9)
+ * - 401: refreshes session once (race-safe via AuthService) then retries; redirects if still unauth (H3)
+ * - 403: permission warning toast
+ * - 404: silent
+ * - 500: error toast
  */
 export const errorInterceptor: HttpInterceptorFn = (req, next) => {
   const router = inject(Router);
   const notifications = inject(NotificationService);
+  const authService = inject(AuthService);
 
   return next(req).pipe(
+    // H9: Retry transient failures with exponential backoff before surfacing them.
+    retry({
+      count: MAX_RETRY_COUNT,
+      delay: (error: unknown, retryCount: number) => {
+        if (error instanceof HttpErrorResponse && RETRYABLE_STATUS_CODES.includes(error.status)) {
+          return timer(Math.pow(2, retryCount) * 500);
+        }
+        throw error;
+      },
+    }),
     catchError((error: HttpErrorResponse) => {
       switch (error.status) {
-        case 401:
-          notifications.warning('Session expired — please sign in from the server portal.');
-          router.navigate(['/401']);
-          break;
+        case 401: {
+          // Let the auth endpoint errors propagate to AuthService to avoid
+          // an infinite refresh loop (interceptor → refresh → /auth/me → 401 → interceptor...).
+          if (req.url.endsWith('/auth/me')) {
+            return throwError(() => error);
+          }
+
+          // H3: If a refresh is already in flight, queue this request until it completes.
+          if (authService.isRefreshingNow) {
+            return authService.refreshing$.pipe(
+              filter((isDone) => isDone),
+              take(1),
+              switchMap(() => next(req)),
+            );
+          }
+
+          // Start a refresh and retry the original request if the session is restored.
+          return authService.refresh().pipe(
+            switchMap((state) => {
+              if (state.authenticated) {
+                return next(req);
+              }
+              notifications.warning('Session expired — please sign in from the server portal.');
+              router.navigate(['/401']);
+              return throwError(() => error);
+            }),
+          );
+        }
         case 403:
           notifications.warning('You do not have permission to perform this action.');
           break;

--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -27,7 +27,7 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
       count: MAX_RETRY_COUNT,
       delay: (error: unknown, retryCount: number) => {
         if (error instanceof HttpErrorResponse && RETRYABLE_STATUS_CODES.includes(error.status)) {
-          return timer(Math.pow(2, retryCount) * 500);
+          return timer(Math.pow(2, retryCount - 1) * 500);
         }
         throw error;
       },
@@ -37,7 +37,7 @@ export const errorInterceptor: HttpInterceptorFn = (req, next) => {
         case 401: {
           // Let the auth endpoint errors propagate to AuthService to avoid
           // an infinite refresh loop (interceptor → refresh → /auth/me → 401 → interceptor...).
-          if (req.url.endsWith('/auth/me')) {
+          if (req.url.includes('/auth/me')) {
             return throwError(() => error);
           }
 

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { Observable, tap, shareReplay, catchError, of } from 'rxjs';
+import { BehaviorSubject, Observable, tap, shareReplay, catchError, of } from 'rxjs';
 import { environment } from '@environments/environment';
 
 export interface AuthUser {
@@ -27,6 +27,21 @@ export class AuthService {
 
   private pending$: Observable<AuthState> | null = null;
 
+  /** Tracks whether a session refresh is currently in flight. */
+  private isRefreshing = false;
+  /** Emits `false` when a refresh starts, `true` when it completes. */
+  private refreshSubject = new BehaviorSubject<boolean>(false);
+
+  /** True while a session refresh HTTP call is in flight. */
+  get isRefreshingNow(): boolean {
+    return this.isRefreshing;
+  }
+
+  /** Observable of the refresh completion state (false = in progress, true = done). */
+  get refreshing$(): Observable<boolean> {
+    return this.refreshSubject.asObservable();
+  }
+
   constructor(private http: HttpClient) {}
 
   /**
@@ -50,11 +65,18 @@ export class AuthService {
     return this.pending$;
   }
 
-  /** Force a fresh fetch (e.g. after login/logout). */
+  /** Force a fresh fetch and signal in-flight state so concurrent 401s can queue. */
   refresh(): Observable<AuthState> {
     this.pending$ = null;
     this.state.set(null);
-    return this.getState();
+    this.isRefreshing = true;
+    this.refreshSubject.next(false);
+    return this.getState().pipe(
+      tap(() => {
+        this.isRefreshing = false;
+        this.refreshSubject.next(true);
+      }),
+    );
   }
 
   isAdmin(): boolean {

--- a/src/app/core/services/auth.service.ts
+++ b/src/app/core/services/auth.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
-import { BehaviorSubject, Observable, tap, shareReplay, catchError, of } from 'rxjs';
+import { BehaviorSubject, Observable, tap, shareReplay, catchError, of, finalize, filter, take, switchMap } from 'rxjs';
 import { environment } from '@environments/environment';
 
 export interface AuthUser {
@@ -67,12 +67,19 @@ export class AuthService {
 
   /** Force a fresh fetch and signal in-flight state so concurrent 401s can queue. */
   refresh(): Observable<AuthState> {
+    if (this.isRefreshing) {
+      return this.refreshSubject.pipe(
+        filter((done) => done),
+        take(1),
+        switchMap(() => this.getState()),
+      );
+    }
     this.pending$ = null;
     this.state.set(null);
     this.isRefreshing = true;
     this.refreshSubject.next(false);
     return this.getState().pipe(
-      tap(() => {
+      finalize(() => {
         this.isRefreshing = false;
         this.refreshSubject.next(true);
       }),


### PR DESCRIPTION
## Résumé

Deux problèmes combinés résolus dans ce PR car les deux modifient `src/app/core/interceptors/error.interceptor.ts`.

---

### closes #49 — [H3] Problème de concurrence lors du rafraîchissement du token

**Problème :** Quand plusieurs requêtes reçoivent un 401 simultanément, chacune tente un refresh indépendant, entraînant des appels en double à `/api/auth/me`.

**Solution :**
- Ajout de `isRefreshing` (flag) et `refreshSubject: BehaviorSubject<boolean>` dans `AuthService`
- Exposition de `isRefreshingNow` et `refreshing$`
- `refresh()` signale l'état in-flight ; les 401 concurrents s'abonnent à `refreshing$` et attendent la fin du refresh avant de réessayer
- Cas de boucle infinie évité : les requêtes vers `/auth/me` elle-même sont exclues du mécanisme de refresh

---

### closes #55 — [H9] Retry HTTP automatique sur erreurs transitoires (429/502/503)

**Problème :** Les erreurs transitoires (429 Too Many Requests, 502 Bad Gateway, 503 Service Unavailable) sont immédiatement montrées à l'utilisateur.

**Solution :**
- Ajout de `retry({ count: 3, delay })` avec backoff exponentiel (500 ms, 1 s, 2 s) pour les codes 429, 502, 503
- Les erreurs non retryables sont propagées immédiatement sans retry

---

## Fichiers modifiés

- `src/app/core/interceptors/error.interceptor.ts` — retry + race guard 401
- `src/app/core/services/auth.service.ts` — BehaviorSubject refresh state

## Validation

- TypeScript strict : aucun `any`, `instanceof HttpErrorResponse` pour typer l'erreur dans `retry`
- Pas de modification du contrat public existant de `AuthService` (rétrocompatible)
- CI (lint + tests + build) à valider via pipeline