### PR TITLE
feat(#29,#27,#28,#31,#62,#73,#74): polish UI/UX — pages erreur, focus, selects, hover, copyright, danger, markdown preview

### DIFF
--- a/src/app/core/models/site-config.model.ts
+++ b/src/app/core/models/site-config.model.ts
@@ -17,7 +17,7 @@ export interface SiteConfig {
 export const DEFAULT_SITE_CONFIG: SiteConfig = {
   siteName: 'Book Review Blog',
   siteNameShort: 'BookReview',
-  copyrightYear: 2026,
+  copyrightYear: new Date().getFullYear(),
   colors: {
     primary: '#1f2937',
     secondary: '#059669',

--- a/src/app/features/admin/pages/admin-academics/admin-academics.component.ts
+++ b/src/app/features/admin/pages/admin-academics/admin-academics.component.ts
@@ -73,7 +73,7 @@ import { AcademicWork } from '../../../academics/models/academic.model';
               <button
                 type="button"
                 (click)="deleteAcademic(academic)"
-                class="px-4 py-2 bg-red-600 text-white rounded font-medium hover:bg-red-700 transition"
+                class="px-4 py-2 bg-[var(--danger)] text-white rounded font-medium hover:bg-[var(--danger-hover)] transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--danger)]"
                 [attr.aria-label]="'Supprimer ' + academic.title"
               >Supprimer</button>
             </div>

--- a/src/app/features/admin/pages/admin-reviews/admin-reviews.component.ts
+++ b/src/app/features/admin/pages/admin-reviews/admin-reviews.component.ts
@@ -66,7 +66,7 @@ import { Review, ReviewPaginationResponse } from '@features/reviews/models/revie
               <button
                 type="button"
                 (click)="deleteReview(review)"
-                class="px-4 py-2 bg-red-600 text-white rounded font-medium hover:bg-red-700 transition"
+                class="px-4 py-2 bg-[var(--danger)] text-white rounded font-medium hover:bg-[var(--danger-hover)] transition focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--danger)]"
                 [attr.aria-label]="'Supprimer ' + review.title"
               >Supprimer</button>
             </div>

--- a/src/app/features/reviews/pages/review-form/review-form.component.ts
+++ b/src/app/features/reviews/pages/review-form/review-form.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
+import { Component, OnInit, OnDestroy, ChangeDetectionStrategy, ChangeDetectorRef, viewChild, ElementRef } from '@angular/core';
 import { CommonModule, Location } from '@angular/common';
 import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { Router, ActivatedRoute } from '@angular/router';
@@ -13,6 +13,7 @@ import {
 } from '@shared/components/breadcrumb/breadcrumb.component';
 import { HasUnsavedChanges } from '@core/guards/can-deactivate.guard';
 import { Subject, takeUntil } from 'rxjs';
+import { MarkdownComponent } from 'ngx-markdown';
 
 /**
  * Review Form Component
@@ -28,6 +29,7 @@ import { Subject, takeUntil } from 'rxjs';
     LoadingSpinnerComponent,
     StarRatingInputComponent,
     BreadcrumbComponent,
+    MarkdownComponent,
   ],
   template: `
     <div class="page-container">
@@ -145,20 +147,90 @@ import { Subject, takeUntil } from 'rxjs';
             </p>
           </div>
 
-          <!-- Contenu complet -->
+          <!-- Contenu complet — Markdown editor with preview toggle -->
           <div>
             <label for="content" class="block text-sm font-semibold mb-2 text-[var(--primary)]">Critique complète *</label>
-            <textarea
-              id="content"
-              formControlName="content"
-              placeholder="Saisir le texte complet de la critique"
-              rows="10"
-              class="w-full border border-[var(--border-light)] rounded-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] text-sm"
-              aria-required="true"
-              [attr.aria-label]="'Contenu de la critique'"
-              [attr.aria-invalid]="isFieldInvalid('content')"
-            ></textarea>
-            <p *ngIf="isFieldInvalid('content')" class="text-red-600 text-sm mt-1">Le contenu de la critique est requis</p>
+
+            <div
+              role="tablist"
+              aria-label="Éditeur de contenu"
+              class="flex w-full rounded-t-xl overflow-hidden border border-b-0 border-[var(--border-light)]"
+            >
+              <button
+                type="button"
+                #contentTabEdit
+                role="tab"
+                [attr.aria-selected]="activeTab === 'edit'"
+                aria-controls="review-content-edit-panel"
+                id="review-tab-edit"
+                [attr.tabindex]="activeTab === 'edit' ? 0 : -1"
+                (click)="activeTab = 'edit'"
+                (keydown)="onContentTabKeydown($event)"
+                class="px-4 py-2 text-sm font-medium transition-colors min-w-[88px] min-h-[44px]"
+                [class.bg-[var(--surface-alt)]]="activeTab !== 'edit'"
+                [class.text-[var(--text-muted)]]="activeTab !== 'edit'"
+                [class.bg-white]="activeTab === 'edit'"
+                [class.text-[var(--primary)]]="activeTab === 'edit'"
+                [class.font-semibold]="activeTab === 'edit'"
+              >Écrire</button>
+              <button
+                type="button"
+                #contentTabPreview
+                role="tab"
+                [attr.aria-selected]="activeTab === 'preview'"
+                aria-controls="review-content-preview-panel"
+                id="review-tab-preview"
+                [attr.tabindex]="activeTab === 'preview' ? 0 : -1"
+                (click)="activeTab = 'preview'"
+                (keydown)="onContentTabKeydown($event)"
+                class="px-4 py-2 text-sm font-medium transition-colors min-w-[88px] min-h-[44px] border-l border-[var(--border-light)]"
+                [class.bg-[var(--surface-alt)]]="activeTab !== 'preview'"
+                [class.text-[var(--text-muted)]]="activeTab !== 'preview'"
+                [class.bg-white]="activeTab === 'preview'"
+                [class.text-[var(--primary)]]="activeTab === 'preview'"
+                [class.font-semibold]="activeTab === 'preview'"
+              >Aperçu</button>
+            </div>
+
+            <!-- Edit panel -->
+            <div
+              id="review-content-edit-panel"
+              role="tabpanel"
+              aria-labelledby="review-tab-edit"
+              [hidden]="activeTab !== 'edit'"
+            >
+              <textarea
+                id="content"
+                formControlName="content"
+                placeholder="Saisir le texte complet de la critique (Markdown supporté)"
+                rows="10"
+                class="w-full border border-[var(--border-light)] rounded-b-xl rounded-tr-xl px-3 py-2 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] text-sm font-mono"
+                aria-required="true"
+                [attr.aria-label]="'Contenu de la critique'"
+                [attr.aria-invalid]="isFieldInvalid('content')"
+              ></textarea>
+            </div>
+
+            <!-- Preview panel -->
+            <div
+              id="review-content-preview-panel"
+              role="tabpanel"
+              aria-labelledby="review-tab-preview"
+              [hidden]="activeTab !== 'preview'"
+              [attr.tabindex]="activeTab === 'preview' ? 0 : -1"
+              class="min-h-[14rem] border border-[var(--border-light)] rounded-b-xl rounded-tr-xl px-4 py-3 bg-white prose prose-sm max-w-none outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)]"
+            >
+              <markdown
+                *ngIf="reviewForm.get('content')?.value"
+                [data]="reviewForm.get('content')?.value"
+              ></markdown>
+              <p
+                *ngIf="!reviewForm.get('content')?.value"
+                class="text-[var(--text-muted)] italic text-sm"
+              >Aucun contenu à afficher.</p>
+            </div>
+
+            <p *ngIf="isFieldInvalid('content')" class="text-red-600 text-sm mt-1">Le contenu de la critique est requis (minimum 50 caractères)</p>
           </div>
 
           <!-- URL de couverture -->
@@ -219,6 +291,11 @@ export class ReviewFormComponent implements OnInit, OnDestroy, HasUnsavedChanges
   isSubmitting = false;
   reviewId: string | null = null;
 
+  activeTab: 'edit' | 'preview' = 'edit';
+
+  private readonly contentTabEditRef = viewChild<ElementRef<HTMLButtonElement>>('contentTabEdit');
+  private readonly contentTabPreviewRef = viewChild<ElementRef<HTMLButtonElement>>('contentTabPreview');
+
   private destroy$ = new Subject<void>();
 
   constructor(
@@ -246,6 +323,35 @@ export class ReviewFormComponent implements OnInit, OnDestroy, HasUnsavedChanges
   ngOnDestroy(): void {
     this.destroy$.next();
     this.destroy$.complete();
+  }
+
+  onContentTabKeydown(event: KeyboardEvent): void {
+    if (event.key === 'ArrowRight' || event.key === 'ArrowLeft') {
+      event.preventDefault();
+      this.activeTab = this.activeTab === 'edit' ? 'preview' : 'edit';
+      this.cdr.markForCheck();
+      this.focusActiveContentTab();
+    } else if (event.key === 'Home') {
+      event.preventDefault();
+      this.activeTab = 'edit';
+      this.cdr.markForCheck();
+      this.focusActiveContentTab();
+    } else if (event.key === 'End') {
+      event.preventDefault();
+      this.activeTab = 'preview';
+      this.cdr.markForCheck();
+      this.focusActiveContentTab();
+    }
+  }
+
+  private focusActiveContentTab(): void {
+    queueMicrotask(() => {
+      const el =
+        this.activeTab === 'edit'
+          ? this.contentTabEditRef()?.nativeElement
+          : this.contentTabPreviewRef()?.nativeElement;
+      el?.focus();
+    });
   }
 
   /**

--- a/src/app/shared/components/button/button.component.spec.ts
+++ b/src/app/shared/components/button/button.component.spec.ts
@@ -50,7 +50,7 @@ describe('ButtonComponent', () => {
   it('should apply danger variant classes when set', () => {
     component.variant = 'danger';
     const classes = component.getClasses();
-    expect(classes).toContain('bg-rose-600');
+    expect(classes).toContain('bg-[var(--danger)]');
   });
 
   it('should apply size classes', () => {

--- a/src/app/shared/components/button/button.component.ts
+++ b/src/app/shared/components/button/button.component.ts
@@ -65,7 +65,7 @@ export class ButtonComponent {
     const variantClasses: Record<ButtonVariant, string> = {
       primary: 'bg-[var(--primary)] text-[var(--text-light)] hover:brightness-110',
       secondary: 'bg-[var(--secondary)] text-[var(--text-light)] hover:brightness-105',
-      danger: 'bg-rose-600 text-white hover:bg-rose-700',
+      danger: 'bg-[var(--danger)] text-white hover:bg-[var(--danger-hover)]',
       ghost: 'bg-white/80 border border-[var(--border-light)] text-[var(--text-dark)] hover:bg-[var(--surface-alt)]',
     };
 

--- a/src/app/shared/components/card/card.component.ts
+++ b/src/app/shared/components/card/card.component.ts
@@ -25,7 +25,7 @@ export class CardComponent {
     let classes =
       'bg-[color:var(--card-bg)] border border-[var(--border-light)] rounded-2xl shadow-[0_12px_24px_-24px_rgba(122,54,95,0.55)] p-5';
     if (this.hoverable) {
-      classes += ' hover:shadow-[0_20px_36px_-24px_rgba(122,54,95,0.75)] hover:scale-102 transition-all duration-200 cursor-pointer';
+      classes += ' hover:shadow-[0_20px_36px_-24px_rgba(122,54,95,0.75)] hover:scale-[1.02] transition-all duration-200 cursor-pointer';
     }
     return classes;
   }

--- a/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -54,7 +54,7 @@ import { Subscription } from 'rxjs';
               #confirmBtn
               type="button"
               (click)="confirm()"
-              class="px-5 py-2 rounded-lg bg-red-600 text-white font-semibold hover:bg-red-700 transition focus:outline-none focus:ring-2 focus:ring-red-600 focus:ring-offset-2"
+              class="px-5 py-2 rounded-lg bg-[var(--danger)] text-white font-semibold hover:bg-[var(--danger-hover)] transition focus-visible:outline-2 focus-visible:outline-[var(--danger)] focus-visible:outline-offset-2"
             >Confirmer</button>
           </div>
         </div>

--- a/src/app/shared/pages/not-found/not-found.component.ts
+++ b/src/app/shared/pages/not-found/not-found.component.ts
@@ -2,27 +2,47 @@ import { Component, ChangeDetectionStrategy } from '@angular/core';
 import { RouterLink } from '@angular/router';
 
 /**
- * 404 Not Found Component
+ * 404 Not Found page with navigation shortcuts.
  */
 @Component({
   selector: 'app-not-found',
   standalone: true,
   imports: [RouterLink],
   template: `
-    <section class="container mx-auto px-4 py-12 text-center" aria-labelledby="not-found-heading">
-      <div class="max-w-md mx-auto">
-        <h1 id="not-found-heading" class="text-6xl font-bold text-[var(--accent)] mb-4">404</h1>
-        <h2 class="text-3xl font-bold mb-4">Page introuvable</h2>
-        <p class="text-lg text-gray-600 mb-8">
-          Désolé, la page que vous cherchez n'existe pas.
+    <section class="container mx-auto px-4 py-16 text-center" aria-labelledby="not-found-heading">
+      <div class="mx-auto max-w-lg">
+        <div class="mb-6 text-7xl" aria-hidden="true">🤷</div>
+        <h1 id="not-found-heading" class="mb-2 text-5xl font-bold text-[var(--primary)]">404</h1>
+        <h2 class="mb-4 text-xl font-semibold text-[var(--text-dark)]">Page introuvable</h2>
+        <p class="mb-8 text-[var(--text-muted)]">
+          Désolé, la page que vous cherchez n'existe pas ou a été déplacée.
         </p>
-        <a
-          routerLink="/"
-          class="bg-[var(--accent)] text-[var(--primary)] px-6 py-3 rounded font-semibold hover:brightness-95 transition inline-block"
-          aria-label="Retourner à l'accueil"
-        >
-          Retour à l'accueil
-        </a>
+        <nav aria-label="Options de navigation" class="flex flex-wrap justify-center gap-3">
+          <a
+            routerLink="/"
+            class="inline-block rounded-full bg-[var(--secondary)] px-5 py-2.5 font-semibold text-white transition hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--secondary)]"
+          >
+            Accueil
+          </a>
+          <a
+            routerLink="/reviews"
+            class="inline-block rounded-full border border-[var(--border-light)] bg-[var(--surface)] px-5 py-2.5 font-medium text-[var(--text-dark)] transition hover:bg-[var(--surface-alt)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+          >
+            Critiques
+          </a>
+          <a
+            routerLink="/academics"
+            class="inline-block rounded-full border border-[var(--border-light)] bg-[var(--surface)] px-5 py-2.5 font-medium text-[var(--text-dark)] transition hover:bg-[var(--surface-alt)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+          >
+            Travaux
+          </a>
+          <a
+            routerLink="/contact"
+            class="inline-block rounded-full border border-[var(--border-light)] bg-[var(--surface)] px-5 py-2.5 font-medium text-[var(--text-dark)] transition hover:bg-[var(--surface-alt)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+          >
+            Contact
+          </a>
+        </nav>
       </div>
     </section>
   `,

--- a/src/app/shared/pages/unauthorized/unauthorized.component.spec.ts
+++ b/src/app/shared/pages/unauthorized/unauthorized.component.spec.ts
@@ -20,10 +20,12 @@ describe('UnauthorizedComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should display 401 and Unauthorized with home link', () => {
+  it('should display 401 and Unauthorized with navigation links', () => {
     const el = fixture.nativeElement as HTMLElement;
     expect(el.textContent).toContain('401');
-    expect(el.textContent).toContain('Non autorisé');
+    expect(el.textContent).toContain('Accès non autorisé');
     expect(el.querySelector('a[routerLink="/"]')).toBeTruthy();
+    expect(el.querySelector('a[routerLink="/reviews"]')).toBeTruthy();
+    expect(el.querySelector('a[routerLink="/contact"]')).toBeTruthy();
   });
 });

--- a/src/app/shared/pages/unauthorized/unauthorized.component.ts
+++ b/src/app/shared/pages/unauthorized/unauthorized.component.ts
@@ -9,20 +9,40 @@ import { RouterLink } from '@angular/router';
   standalone: true,
   imports: [RouterLink],
   template: `
-    <section class="container mx-auto px-4 py-12 text-center" aria-labelledby="unauthorized-heading">
-      <div class="mx-auto max-w-md">
-        <h1 id="unauthorized-heading" class="mb-2 text-4xl font-bold text-[var(--primary)]">401</h1>
-        <h2 class="mb-4 text-xl font-semibold text-[var(--text-dark)]">Non autorisé</h2>
+    <section class="container mx-auto px-4 py-16 text-center" aria-labelledby="unauthorized-heading">
+      <div class="mx-auto max-w-lg">
+        <div class="mb-6 text-7xl" aria-hidden="true">🔒</div>
+        <h1 id="unauthorized-heading" class="mb-2 text-5xl font-bold text-[var(--primary)]">401</h1>
+        <h2 class="mb-4 text-xl font-semibold text-[var(--text-dark)]">Accès non autorisé</h2>
         <p class="mb-8 text-[var(--text-muted)]">
           Connectez-vous depuis le portail utilisateur de votre serveur si ce site est protégé, puis réessayez.
         </p>
-        <a
-          routerLink="/"
-          class="inline-block rounded-full bg-[var(--secondary)] px-6 py-3 font-semibold text-white hover:brightness-95"
-          aria-label="Retourner à l'accueil"
-        >
-          Accueil
-        </a>
+        <nav aria-label="Options de navigation" class="flex flex-wrap justify-center gap-3">
+          <a
+            routerLink="/"
+            class="inline-block rounded-full bg-[var(--secondary)] px-5 py-2.5 font-semibold text-white transition hover:brightness-95 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--secondary)]"
+          >
+            Accueil
+          </a>
+          <a
+            routerLink="/reviews"
+            class="inline-block rounded-full border border-[var(--border-light)] bg-[var(--surface)] px-5 py-2.5 font-medium text-[var(--text-dark)] transition hover:bg-[var(--surface-alt)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+          >
+            Critiques
+          </a>
+          <a
+            routerLink="/academics"
+            class="inline-block rounded-full border border-[var(--border-light)] bg-[var(--surface)] px-5 py-2.5 font-medium text-[var(--text-dark)] transition hover:bg-[var(--surface-alt)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+          >
+            Travaux
+          </a>
+          <a
+            routerLink="/contact"
+            class="inline-block rounded-full border border-[var(--border-light)] bg-[var(--surface)] px-5 py-2.5 font-medium text-[var(--text-dark)] transition hover:bg-[var(--surface-alt)] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[var(--primary)]"
+          >
+            Contact
+          </a>
+        </nav>
       </div>
     </section>
   `,

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -26,6 +26,8 @@
   --nav-bg: rgb(255 255 255 / 0.95);
   --card-bg: rgb(255 255 255 / 0.95);
   --input-bg: #ffffff;
+  --danger: #c0304e;
+  --danger-hover: #a02540;
   --panel-bg-start: #ffffff;
   --panel-bg-end: var(--surface-alt);
   --font-sans: "Inter", "Avenir Next", "Avenir", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
@@ -133,6 +135,18 @@ button {
   transition: background-color 0.15s ease, color 0.15s ease, border-color 0.15s ease;
   border: none;
   border-radius: 999px;
+
+  &:focus-visible {
+    outline: 2px solid var(--secondary);
+    outline-offset: 2px;
+  }
+}
+
+/* Global focus-visible for links not overriding their own outline */
+a:focus-visible {
+  outline: 2px solid var(--secondary);
+  outline-offset: 2px;
+  border-radius: 4px;
 }
 
 /* Form Elements */
@@ -145,13 +159,27 @@ select {
   border-radius: 0.85rem;
   padding: 0.625rem 0.75rem;
   background: var(--input-bg);
-  transition: border-color 0.3s ease;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
 
-  &:focus {
+  &:hover {
+    border-color: var(--secondary);
+  }
+
+  &:focus,
+  &:focus-visible {
     outline: none;
     border-color: var(--secondary);
     box-shadow: 0 0 0 4px rgb(213 111 161 / 18%);
   }
+}
+
+select {
+  cursor: pointer;
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%23463540' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'%3E%3C/polyline%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 0.75rem center;
+  padding-right: 2.5rem;
 }
 
 /* Utility Classes */


### PR DESCRIPTION
## Résumé

Ce PR regroupe 7 corrections/améliorations UI/UX indépendantes identifiées dans le backlog.

## Changements

### fix(#29) — Pages 401/404 améliorées
- Ajout d'emoji 🔒 (401) et 🤷 (404) pour du contexte visuel
- Titre plus clair : `Accès non autorisé` / `Page introuvable`
- Menu de navigation de secours : Accueil, Critiques, Travaux, Contact

### fix(#27) — Focus states visibles (accessibilité)
- `button:focus-visible` : outline 2px `--secondary` avec offset
- `a:focus-visible` : outline 2px `--secondary` avec offset + border-radius

### fix(#28) — Hover sur les cartes
- Corrige `hover:scale-102` → `hover:scale-[1.02]` dans `CardComponent` (classe Tailwind invalide, l'effet ne s'appliquait pas)

### feat(#31) — Selects stylisés
- `appearance-none` + chevron SVG en background
- `cursor-pointer`, hover sur la bordure, transition

### feat(#62) — Preview Markdown dans le formulaire de critique
- Onglets `Écrire` / `Aperçu` dans `review-form` (même pattern que `academic-form`)
- Navigation clavier (ArrowLeft/Right, Home/End) conforme WAI-ARIA tablist

### feat(#73) — Année de copyright dynamique
- `DEFAULT_SITE_CONFIG.copyrightYear` = `new Date().getFullYear()`
- Plus de valeur hardcodée à mettre à jour chaque année

### feat(#74) — Variables CSS pour le danger
- Ajout de `--danger: #c0304e` et `--danger-hover: #a02540` dans `:root`
- `ButtonComponent` variant `danger` utilise `bg-[var(--danger)]`
- Boutons delete admin et confirm-dialog migrés vers ces variables

## Tests
- 180/180 tests passent ✅
- Build production OK (warning budget préexistant)