### PR TITLE
feat(#60): DTO layer with date deserialization for reviews and academics

### DIFF
--- a/src/app/core/dto/academic.dto.ts
+++ b/src/app/core/dto/academic.dto.ts
@@ -1,0 +1,33 @@
+import { AcademicWork } from '@features/academics/models/academic.model';
+
+/**
+ * Raw API response shape for an AcademicWork.
+ * Dates arrive as ISO strings from the JSON payload.
+ */
+export interface AcademicWorkDto {
+  id: string;
+  title: string;
+  summary: string;
+  content: string;
+  imageUrl?: string;
+  workType: string;
+  context: string;
+  year: number;
+  theme?: string | null;
+  excerpt?: string;
+  sourceUrl?: string;
+  publishedAt: string;
+  updatedAt: string;
+  createdBy: string;
+  isPublished: boolean;
+  featured?: boolean;
+}
+
+/** Maps a raw API DTO to the typed domain model (strings → Dates). */
+export function fromAcademicWorkDto(dto: AcademicWorkDto): AcademicWork {
+  return {
+    ...dto,
+    publishedAt: new Date(dto.publishedAt),
+    updatedAt: new Date(dto.updatedAt),
+  };
+}

--- a/src/app/core/dto/index.ts
+++ b/src/app/core/dto/index.ts
@@ -1,0 +1,2 @@
+export { ReviewDto, fromReviewDto } from './review.dto';
+export { AcademicWorkDto, fromAcademicWorkDto } from './academic.dto';

--- a/src/app/core/dto/review.dto.ts
+++ b/src/app/core/dto/review.dto.ts
@@ -1,0 +1,32 @@
+import { Review } from '@features/reviews/models/review.model';
+
+/**
+ * Raw API response shape for a Review.
+ * Dates arrive as ISO strings from the JSON payload.
+ */
+export interface ReviewDto {
+  id: string;
+  title: string;
+  author: string;
+  bookTitle: string;
+  bookAuthor: string;
+  rating: number;
+  genre: string;
+  description: string;
+  content: string;
+  imageUrl?: string;
+  publishedAt: string;
+  updatedAt: string;
+  createdBy: string;
+  isPublished: boolean;
+  featured?: boolean;
+}
+
+/** Maps a raw API DTO to the typed domain model (strings → Dates). */
+export function fromReviewDto(dto: ReviewDto): Review {
+  return {
+    ...dto,
+    publishedAt: new Date(dto.publishedAt),
+    updatedAt: new Date(dto.updatedAt),
+  };
+}

--- a/src/app/features/academics/services/academic.service.ts
+++ b/src/app/features/academics/services/academic.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { tap, catchError, retry } from 'rxjs/operators';
+import { tap, catchError, retry, map } from 'rxjs/operators';
 import { throwError } from 'rxjs';
 import { ApiService } from '@core/services/api.service';
 import { AcademicWork, AcademicFilter, AcademicPaginationResponse } from '../models/academic.model';
+import { AcademicWorkDto, fromAcademicWorkDto } from '@core/dto/academic.dto';
 
 /**
  * Academic Service
@@ -26,8 +27,12 @@ export class AcademicService {
     this.loading$.next(true);
     const params = this.buildParams(filters);
 
-    return this.apiService.get<AcademicPaginationResponse>('academics', { params }).pipe(
+    return this.apiService.get<{ data: AcademicWorkDto[]; total: number; page: number; limit: number; totalPages: number }>('academics', { params }).pipe(
       retry(2),
+      map((response) => ({
+        ...response,
+        data: response.data.map(fromAcademicWorkDto),
+      })),
       tap((response) => {
         this.academics$.next(response.data);
         this.loading$.next(false);
@@ -45,7 +50,8 @@ export class AcademicService {
   getAcademicById(id: string): Observable<AcademicWork> {
     this.loading$.next(true);
 
-    return this.apiService.get<AcademicWork>(`academics/${id}`).pipe(
+    return this.apiService.get<AcademicWorkDto>(`academics/${id}`).pipe(
+      map(fromAcademicWorkDto),
       tap((academic) => {
         this.selectedAcademic$.next(academic);
         this.loading$.next(false);

--- a/src/app/features/reviews/services/review.service.ts
+++ b/src/app/features/reviews/services/review.service.ts
@@ -1,9 +1,10 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { tap, catchError, retry } from 'rxjs/operators';
+import { tap, catchError, retry, map } from 'rxjs/operators';
 import { throwError } from 'rxjs';
 import { ApiService } from '@core/services/api.service';
 import { Review, ReviewFilter, ReviewPaginationResponse } from '../models/review.model';
+import { ReviewDto, fromReviewDto } from '@core/dto/review.dto';
 
 /**
  * Review Service
@@ -26,8 +27,12 @@ export class ReviewService {
     this.loading$.next(true);
     const params = this.buildParams(filters);
 
-    return this.apiService.get<ReviewPaginationResponse>('reviews', { params }).pipe(
+    return this.apiService.get<{ data: ReviewDto[]; total: number; page: number; limit: number; totalPages: number }>('reviews', { params }).pipe(
       retry(2),
+      map((response) => ({
+        ...response,
+        data: response.data.map(fromReviewDto),
+      })),
       tap((response) => {
         this.reviews$.next(response.data);
         this.loading$.next(false);
@@ -47,7 +52,8 @@ export class ReviewService {
   getReviewById(id: string): Observable<Review> {
     this.loading$.next(true);
 
-    return this.apiService.get<Review>(`reviews/${id}`).pipe(
+    return this.apiService.get<ReviewDto>(`reviews/${id}`).pipe(
+      map(fromReviewDto),
       tap((review) => {
         this.selectedReview$.next(review);
         this.loading$.next(false);


### PR DESCRIPTION
## Summary

Implements issue #60 — DTO layer to ensure dates from the API are always proper `Date` objects in the domain layer.

## Changes

### New files
- `src/app/core/dto/review.dto.ts` — `ReviewDto` interface + `fromReviewDto()` mapper
- `src/app/core/dto/academic.dto.ts` — `AcademicWorkDto` interface + `fromAcademicWorkDto()` mapper
- `src/app/core/dto/index.ts` — barrel export

### Updated services
- `ReviewService.getReviews()` — typed against `ReviewDto[]`, maps via `fromReviewDto()`
- `ReviewService.getReviewById()` — typed against `ReviewDto`, maps via `fromReviewDto()`
- `AcademicService.getAcademics()` — same pattern
- `AcademicService.getAcademicById()` — same pattern

## Why

Angular's `HttpClient` deserializes JSON dates as plain strings. Without a mapper, components using `.toLocaleDateString()` or date pipes on `review.publishedAt` were working by accident (string coercion). The DTO layer makes the domain contract explicit: dates in the model are always `Date` objects.

## Validation
- ✅ 180/180 tests pass (`npm run test:ci`)
- ✅ Production build succeeds (`npm run build:prod`)

Closes #60