### PR TITLE
feat(#70): add LoggerService — centralised structured logging

### DIFF
--- a/src/app/core/services/logger.service.spec.ts
+++ b/src/app/core/services/logger.service.spec.ts
@@ -1,0 +1,88 @@
+import { TestBed } from '@angular/core/testing';
+import { LoggerService } from './logger.service';
+
+describe('LoggerService', () => {
+  let service: LoggerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(LoggerService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('in development mode (isProd = false)', () => {
+    beforeEach(() => {
+      (service as unknown as { isProd: boolean }).isProd = false;
+    });
+
+    it('log() should call console.log', () => {
+      spyOn(console, 'log');
+      service.log('test message');
+      expect(console.log).toHaveBeenCalledWith('[INFO] test message');
+    });
+
+    it('log() should include context when provided', () => {
+      spyOn(console, 'log');
+      service.log('msg', { key: 'value' });
+      expect(console.log).toHaveBeenCalledWith('[INFO] msg', { key: 'value' });
+    });
+
+    it('debug() should call console.debug', () => {
+      spyOn(console, 'debug');
+      service.debug('debug message');
+      expect(console.debug).toHaveBeenCalledWith('[DEBUG] debug message');
+    });
+
+    it('warn() should call console.warn', () => {
+      spyOn(console, 'warn');
+      service.warn('warning');
+      expect(console.warn).toHaveBeenCalledWith('[WARN] warning');
+    });
+
+    it('error() should call console.error with message', () => {
+      spyOn(console, 'error');
+      service.error('error message');
+      expect(console.error).toHaveBeenCalledWith('[ERROR] error message');
+    });
+
+    it('error() should include Error object when provided', () => {
+      spyOn(console, 'error');
+      const err = new Error('boom');
+      service.error('failed', err);
+      expect(console.error).toHaveBeenCalledWith('[ERROR] failed', err);
+    });
+  });
+
+  describe('in production mode (isProd = true)', () => {
+    beforeEach(() => {
+      (service as unknown as { isProd: boolean }).isProd = true;
+    });
+
+    it('log() should NOT call console.log', () => {
+      spyOn(console, 'log');
+      service.log('should be silent');
+      expect(console.log).not.toHaveBeenCalled();
+    });
+
+    it('debug() should NOT call console.debug', () => {
+      spyOn(console, 'debug');
+      service.debug('silent');
+      expect(console.debug).not.toHaveBeenCalled();
+    });
+
+    it('warn() should still call console.warn', () => {
+      spyOn(console, 'warn');
+      service.warn('prod warning');
+      expect(console.warn).toHaveBeenCalledWith('[WARN] prod warning');
+    });
+
+    it('error() should still call console.error', () => {
+      spyOn(console, 'error');
+      service.error('prod error');
+      expect(console.error).toHaveBeenCalledWith('[ERROR] prod error');
+    });
+  });
+});

--- a/src/app/core/services/logger.service.ts
+++ b/src/app/core/services/logger.service.ts
@@ -1,0 +1,62 @@
+import { Injectable } from '@angular/core';
+import { environment } from '@environments/environment';
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export interface LogContext {
+  [key: string]: unknown;
+}
+
+/**
+ * Centralised logging service.
+ *
+ * - In production (`environment.production === true`) only `warn` and `error`
+ *   messages are emitted; debug/info are silenced.
+ * - In development all levels are forwarded to the browser console.
+ * - Components should inject this service instead of calling `console.*` directly.
+ */
+@Injectable({
+  providedIn: 'root',
+})
+export class LoggerService {
+  private readonly isProd = environment.production;
+
+  /**
+   * Debug-level message — silenced in production.
+   */
+  debug(message: string, context?: LogContext): void {
+    if (!this.isProd) {
+      // eslint-disable-next-line no-console
+      console.debug(`[DEBUG] ${message}`, ...(context ? [context] : []));
+    }
+  }
+
+  /**
+   * Informational message — silenced in production.
+   */
+  log(message: string, context?: LogContext): void {
+    if (!this.isProd) {
+      // eslint-disable-next-line no-console
+      console.log(`[INFO] ${message}`, ...(context ? [context] : []));
+    }
+  }
+
+  /**
+   * Warning — emitted in all environments.
+   */
+  warn(message: string, context?: LogContext): void {
+    // eslint-disable-next-line no-console
+    console.warn(`[WARN] ${message}`, ...(context ? [context] : []));
+  }
+
+  /**
+   * Error — emitted in all environments.
+   */
+  error(message: string, err?: unknown, context?: LogContext): void {
+    const extras: unknown[] = [];
+    if (err !== undefined) extras.push(err);
+    if (context) extras.push(context);
+    // eslint-disable-next-line no-console
+    console.error(`[ERROR] ${message}`, ...extras);
+  }
+}

--- a/src/app/core/services/storage.service.ts
+++ b/src/app/core/services/storage.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+import { LoggerService } from './logger.service';
 
 /**
  * Storage Service
@@ -8,6 +9,8 @@ import { Injectable } from '@angular/core';
   providedIn: 'root',
 })
 export class StorageService {
+  constructor(private logger: LoggerService) {}
+
   /**
    * Save data to localStorage
    */
@@ -15,7 +18,7 @@ export class StorageService {
     try {
       localStorage.setItem(key, JSON.stringify(value));
     } catch (error) {
-      console.error('Error saving to localStorage:', error);
+      this.logger.error('Error saving to localStorage:', error, { key });
     }
   }
 
@@ -29,7 +32,7 @@ export class StorageService {
       const item = localStorage.getItem(key);
       return item ? JSON.parse(item) : null;
     } catch (error) {
-      console.error('Error reading from localStorage:', error);
+      this.logger.error('Error reading from localStorage:', error, { key });
       return null;
     }
   }
@@ -41,7 +44,7 @@ export class StorageService {
     try {
       localStorage.removeItem(key);
     } catch (error) {
-      console.error('Error removing from localStorage:', error);
+      this.logger.error('Error removing from localStorage:', error, { key });
     }
   }
 
@@ -52,7 +55,7 @@ export class StorageService {
     try {
       localStorage.clear();
     } catch (error) {
-      console.error('Error clearing localStorage:', error);
+      this.logger.error('Error clearing localStorage:', error);
     }
   }
 
@@ -63,4 +66,3 @@ export class StorageService {
     return localStorage.getItem(key) !== null;
   }
 }
-

--- a/src/app/features/academics/pages/academic-form/academic-form.component.ts
+++ b/src/app/features/academics/pages/academic-form/academic-form.component.ts
@@ -14,6 +14,7 @@ import { Router, ActivatedRoute } from '@angular/router';
 import { HttpClient, HttpEventType } from '@angular/common/http';
 import { AcademicService } from '../../services/academic.service';
 import { NotificationService } from '@core/services/notification.service';
+import { LoggerService } from '@core/services/logger.service';
 import { ButtonComponent } from '@shared/components/button/button.component';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import {
@@ -401,6 +402,7 @@ export class AcademicFormComponent implements OnInit, OnDestroy, HasUnsavedChang
     private fb: FormBuilder,
     private academicService: AcademicService,
     private notificationService: NotificationService,
+    private logger: LoggerService,
     private router: Router,
     private route: ActivatedRoute,
     private http: HttpClient,
@@ -459,7 +461,7 @@ export class AcademicFormComponent implements OnInit, OnDestroy, HasUnsavedChang
         },
         error: (error) => {
           this.notificationService.error('Impossible de charger le travail académique');
-          console.error('Error loading academic:', error);
+          this.logger.error('Error loading academic:', error, { academicId: this.academicId });
           this.isLoading = false;
           this.cdr.markForCheck();
         },
@@ -563,7 +565,7 @@ export class AcademicFormComponent implements OnInit, OnDestroy, HasUnsavedChang
           }
         },
         error: (error) => {
-          console.error('Image upload error:', error);
+          this.logger.error('Image upload error:', error);
           this.uploadError = "Échec de l'envoi de l'image. Veuillez réessayer.";
           this.imagePreview.set(null);
           this.isUploading = false;
@@ -641,7 +643,7 @@ export class AcademicFormComponent implements OnInit, OnDestroy, HasUnsavedChang
       },
       error: (error) => {
         this.notificationService.error('Impossible de sauvegarder le travail académique');
-        console.error('Error saving academic:', error);
+        this.logger.error('Error saving academic:', error);
         this.isSubmitting = false;
         this.cdr.markForCheck();
       },

--- a/src/app/features/reviews/pages/review-form/review-form.component.ts
+++ b/src/app/features/reviews/pages/review-form/review-form.component.ts
@@ -4,6 +4,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { Router, ActivatedRoute } from '@angular/router';
 import { ReviewService } from '../../services/review.service';
 import { NotificationService } from '@core/services/notification.service';
+import { LoggerService } from '@core/services/logger.service';
 import { ButtonComponent } from '@shared/components/button/button.component';
 import { LoadingSpinnerComponent } from '@shared/components/loading-spinner/loading-spinner.component';
 import { StarRatingInputComponent } from '@shared/components/star-rating-input/star-rating-input.component';
@@ -225,6 +226,7 @@ export class ReviewFormComponent implements OnInit, OnDestroy, HasUnsavedChanges
     private fb: FormBuilder,
     private reviewService: ReviewService,
     private notificationService: NotificationService,
+    private logger: LoggerService,
     private router: Router,
     private route: ActivatedRoute,
     private location: Location,
@@ -283,7 +285,7 @@ export class ReviewFormComponent implements OnInit, OnDestroy, HasUnsavedChanges
         },
         error: (error) => {
           this.notificationService.error('Impossible de charger la critique');
-          console.error('Error loading review:', error);
+          this.logger.error('Error loading review:', error, { reviewId: this.reviewId });
           this.isLoading = false;
           this.cdr.markForCheck();
         },
@@ -337,7 +339,7 @@ export class ReviewFormComponent implements OnInit, OnDestroy, HasUnsavedChanges
       },
       error: (error) => {
         this.notificationService.error('Impossible d\'enregistrer la critique');
-        console.error('Error saving review:', error);
+        this.logger.error('Error saving review:', error);
         this.isSubmitting = false;
         this.cdr.markForCheck();
       },


### PR DESCRIPTION
## Summary

Implements issue #70 — replace scattered `console.*` calls with a centralised `LoggerService`.

## Changes

### New
- `src/app/core/services/logger.service.ts` — `debug/log/warn/error` methods
- `src/app/core/services/logger.service.spec.ts` — 11 unit tests

### Updated
- `StorageService` — 4 `console.error` → `logger.error` with context `{ key }`
- `ReviewFormComponent` — 2 `console.error` → `logger.error`
- `AcademicFormComponent` — 3 `console.error` → `logger.error`

## Behaviour

| Level | Dev | Prod |
|-------|-----|------|
| debug | ✅ console.debug | 🔇 silent |
| log   | ✅ console.log   | 🔇 silent |
| warn  | ✅ console.warn  | ✅ console.warn |
| error | ✅ console.error | ✅ console.error |

## Validation
- ✅ 191/191 tests pass
- ✅ No remaining `console.*` calls in non-test non-logger source files

Closes #70