### PR TITLE
feat(#68): dark mode support via prefers-color-scheme

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -221,7 +221,7 @@ select {
 }
 
 .card-container {
-  background: #fff;
+  background: var(--card-bg);
   border: 1px solid var(--border-light);
   border-radius: 1rem;
   box-shadow: 0 12px 28px -24px rgb(122 54 95 / 55%);
@@ -250,4 +250,41 @@ select {
 .luxe-title {
   font-family: var(--font-luxe);
   letter-spacing: 0.02em;
+}
+
+/* ============================================================
+ * DARK MODE — prefers-color-scheme: dark
+ * All tokens redefined; components use vars so they adapt
+ * automatically without any template changes.
+ * ============================================================ */
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+    --primary: #e8a0c8;
+    --secondary: #d56fa1;
+    --accent: #b06090;
+    --accent-strong: #e8a0c8;
+    --surface: #150a11;
+    --surface-alt: #1e0e18;
+    --text-dark: #f2dde8;
+    --text-light: #150a11;
+    --text-muted: #c49ab4;
+    --border-light: #3d1f30;
+    --header-bg: rgb(21 10 17 / 0.9);
+    --nav-bg: rgb(30 14 24 / 0.97);
+    --card-bg: rgb(30 14 24 / 0.95);
+    --input-bg: #2a1020;
+    --panel-bg-start: #1e0e18;
+    --panel-bg-end: #270f1e;
+    --danger: #e05070;
+    --danger-hover: #c5405a;
+  }
+
+  html, body {
+    background-color: var(--surface);
+    background-image:
+      radial-gradient(circle at 15% 20%, #2a0e1e 0%, transparent 35%),
+      radial-gradient(circle at 85% 0%, #230b18 0%, transparent 30%),
+      linear-gradient(180deg, #170c13 0%, #1c0f17 100%);
+  }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,7 @@ module.exports = {
   content: [
     "./src/**/*.{html,ts}",
   ],
+  darkMode: 'media',
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## Summary

Implements issue #68 — full dark mode following the OS `prefers-color-scheme: dark` preference.

## Approach

The app is already fully CSS-variable-based, so dark mode is achieved by overriding all `:root` tokens inside a `@media (prefers-color-scheme: dark)` block — **no template changes needed**.

## Changes

- `tailwind.config.js` — added `darkMode: 'media'`
- `src/styles.scss`:
  - New `@media (prefers-color-scheme: dark)` block with deep purple/pink palette
  - Body background gradient overridden for dark mode
  - Fixed `.card-container` hardcoded `#fff` → `var(--card-bg)`
  - `--danger` / `--danger-hover` tokens also updated in dark palette

## Dark palette
| Token | Light | Dark |
|-------|-------|------|
| `--surface` | `#fff8fc` | `#150a11` |
| `--surface-alt` | `#ffeef7` | `#1e0e18` |
| `--text-dark` | `#3d2031` | `#f2dde8` |
| `--text-muted` | `#463540` | `#c49ab4` |
| `--card-bg` | `rgb(255 255 255 / .95)` | `rgb(30 14 24 / .95)` |
| `--primary` | `#7a365f` | `#e8a0c8` |

## Validation
- ✅ 180/180 tests pass
- ✅ Build OK

Closes #68