### PR TITLE
feat(#59): extract ListPageShellComponent — shared layout for list pages

### DIFF
--- a/src/app/features/academics/pages/academic-list/academic-list.component.ts
+++ b/src/app/features/academics/pages/academic-list/academic-list.component.ts
@@ -11,9 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { AcademicService } from '../../services/academic.service';
 import { AcademicWork } from '../../models/academic.model';
 import { CardComponent } from '@shared/components/card/card.component';
-import { ReviewCardSkeletonComponent } from '@shared/components/review-card-skeleton/review-card-skeleton.component';
-import { ButtonComponent } from '@shared/components/button/button.component';
-import { PaginationComponent } from '@shared/components/pagination/pagination.component';
+import { ListPageShellComponent } from '@shared/components/list-page-shell/list-page-shell.component';
 import { Subject, takeUntil, BehaviorSubject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
@@ -30,132 +28,99 @@ import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
     RouterLink,
     FormsModule,
     CardComponent,
-    ReviewCardSkeletonComponent,
-    ButtonComponent,
-    PaginationComponent,
+    ListPageShellComponent,
   ],
   template: `
-    <div class=\"page-container\">
-      <div class=\"mb-6\">
-        <h1 class=\"mb-1 text-3xl font-bold text-[var(--primary)]\">Travaux Académiques</h1>
+    <div class="page-container">
+      <div class="mb-6">
+        <h1 class="mb-1 text-3xl font-bold text-[var(--primary)]">Travaux Académiques</h1>
       </div>
 
-      <div class=\"mb-6 pinterest-panel p-4 md:p-5\">
-        <h2 class=\"mb-3 text-lg font-semibold text-[var(--primary)]\">Recherche &amp; filtres</h2>
-        <div class=\"grid grid-cols-1 md:grid-cols-4 gap-4\">
+      <app-list-page-shell
+        [loading]="(isLoading$ | async) ?? false"
+        [error]="(error$ | async) ?? null"
+        errorTitle="Erreur lors du chargement des travaux académiques"
+        [isEmpty]="((academics$ | async)?.length ?? 0) === 0"
+        emptyMessage="Aucun travail académique trouvé. Essayez d'ajuster vos filtres."
+        [currentPage]="currentPage"
+        [totalPages]="totalPages"
+        [total]="totalItems"
+        [limit]="pageSize"
+        (retryClick)="retryLoadAcademics()"
+        (pageChange)="onPaginationChange($event)"
+      >
+        <!-- Filters -->
+        <div filters class="grid grid-cols-1 md:grid-cols-4 gap-4">
           <input
-            type=\"text\"
-            placeholder=\"Rechercher un travail académique...\"
-            [(ngModel)]=\"searchQuery\"
-            (ngModelChange)=\"onSearchQueryInput()\"
-            class=\"border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white\"
-            aria-label=\"Rechercher un travail académique\"
+            type="text"
+            placeholder="Rechercher un travail académique..."
+            [(ngModel)]="searchQuery"
+            (ngModelChange)="onSearchQueryInput()"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-[var(--input-bg)]"
+            aria-label="Rechercher un travail académique"
           />
           <select
-            [(ngModel)]=\"selectedTheme\"
-            (change)=\"onFilterChange()\"
-            class=\"border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white\"
-            aria-label=\"Filtrer par thème\"
+            [(ngModel)]="selectedTheme"
+            (change)="onFilterChange()"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-[var(--input-bg)]"
+            aria-label="Filtrer par thème"
           >
-            <option value=\"\">Tous les thèmes</option>
-            <option value=\"literature\">Littérature</option>
-            <option value=\"philosophy\">Philosophie</option>
-            <option value=\"history\">Histoire</option>
-            <option value=\"linguistics\">Linguistique</option>
+            <option value="">Tous les thèmes</option>
+            <option value="literature">Littérature</option>
+            <option value="philosophy">Philosophie</option>
+            <option value="history">Histoire</option>
+            <option value="linguistics">Linguistique</option>
           </select>
           <select
-            [(ngModel)]=\"selectedSort\"
-            (change)=\"onFilterChange()\"
-            class=\"border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white\"
-            aria-label=\"Trier les travaux académiques\"
+            [(ngModel)]="selectedSort"
+            (change)="onFilterChange()"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-[var(--input-bg)]"
+            aria-label="Trier les travaux académiques"
           >
-            <option value=\"\">Trier par</option>
-            <option value=\"newest\">Plus récents</option>
-            <option value=\"oldest\">Plus anciens</option>
+            <option value="">Trier par</option>
+            <option value="newest">Plus récents</option>
+            <option value="oldest">Plus anciens</option>
           </select>
           <button
-            (click)=\"resetFilters()\"
-            class=\"bg-white text-[var(--primary)] border border-[var(--border-light)] rounded-full px-3 py-2 hover:bg-[var(--surface-alt)]\"
+            (click)="resetFilters()"
+            class="bg-[var(--input-bg)] text-[var(--primary)] border border-[var(--border-light)] rounded-full px-3 py-2 hover:bg-[var(--surface-alt)]"
           >
             Réinitialiser
           </button>
         </div>
-      </div>
 
-      <!-- Error State -->
-      <div *ngIf="error$ | async as error" class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-6" role="alert">
-        <p class="font-bold mb-2">Erreur lors du chargement des travaux académiques. Veuillez réessayer.</p>
-        <p class="text-sm mb-3">{{ error }}</p>
-        <button (click)="retryLoadAcademics()" class="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700">
-          Réessayer
-        </button>
-      </div>
-
-      <div [attr.aria-busy]=\"(isLoading$ | async) === true\" aria-live=\"polite\">
-        <!-- Loading placeholders -->
-        <div
-          *ngIf=\"isLoading$ | async\"
-          class=\"columns-1 md:columns-2 xl:columns-3 gap-6 space-y-6\"
+        <!-- Academic cards -->
+        <app-card
+          items
+          *ngFor="let academic of academics$ | async; trackBy: trackByAcademicId"
+          [hoverable]="true"
+          class="break-inside-avoid block mb-6"
         >
-          <app-review-card-skeleton
-            *ngFor=\"let s of skeletonSlots; trackBy: trackBySkeletonSlot\"
-          ></app-review-card-skeleton>
-        </div>
-
-        <!-- Academics List -->
-        <div
-          *ngIf=\"(isLoading$ | async) === false\"
-          class=\"columns-1 md:columns-2 xl:columns-3 gap-6 space-y-6\"
-        >
-          <app-card
-            *ngFor=\"let academic of academics$ | async; trackBy: trackByAcademicId\"
-            [hoverable]=\"true\"
-            class=\"break-inside-avoid block mb-6\"
+          <a
+            [routerLink]="['\/academics', academic.id]"
+            class="group -m-1 block rounded-xl p-1 no-underline outline-none ring-[var(--accent)] transition focus-visible:ring-2"
+            [attr.aria-label]="'Ouvrir le travail : ' + academic.title"
           >
-            <a
-              [routerLink]=\"['/academics', academic.id]\"
-              class=\"group -m-1 block rounded-xl p-1 no-underline outline-none ring-[var(--accent)] transition focus-visible:ring-2\"
-              [attr.aria-label]=\"'Ouvrir le travail : ' + academic.title\"
-            >
-              <h3 class=\"text-xl font-semibold mb-2 text-[var(--primary)] group-hover:text-[var(--accent-strong)]\">
-                {{ academic.title }}
-              </h3>
-              <p class=\"text-sm text-[var(--text-muted)] mb-3\">{{ academic.workType }} ({{ academic.year }})</p>
-              <p class=\"text-sm mb-2 text-[var(--text-dark)]\">
-                <strong class=\"text-[var(--primary)]\">Thème :</strong>
-                <span class=\"inline-block px-2 py-1 rounded-full bg-[var(--surface-alt)] text-[var(--accent-strong)]\">
-                  {{ academic.theme }}
-                </span>
-              </p>
-              <p class=\"text-sm text-[var(--text-dark)] line-clamp-3 mb-3\">{{ academic.summary }}</p>
-              <span class=\"font-semibold text-[var(--accent-strong)] group-hover:text-[var(--primary)]\">Lire →</span>
-            </a>
-          </app-card>
-        </div>
-      </div>
-
-      <!-- No Results -->
-      <div *ngIf=\"(academics$ | async)?.length === 0 && (isLoading$ | async) === false\" class=\"text-center py-12\">
-        <p class=\"text-xl text-[var(--text-muted)]\">Aucun travail académique trouvé. Essayez d'ajuster vos filtres.</p>
-      </div>
-
-      <!-- Pagination -->
-      <app-pagination
-        *ngIf=\"(isLoading$ | async) === false && totalItems > 0\"
-        [currentPage]=\"currentPage\"
-        [totalPages]=\"totalPages\"
-        [total]=\"totalItems\"
-        [limit]=\"pageSize\"
-        (pageChange)=\"onPaginationChange($event)\"
-      ></app-pagination>
+            <h3 class="text-xl font-semibold mb-2 text-[var(--primary)] group-hover:text-[var(--accent-strong)]">
+              {{ academic.title }}
+            </h3>
+            <p class="text-sm text-[var(--text-muted)] mb-3">{{ academic.workType }} ({{ academic.year }})</p>
+            <p class="text-sm mb-2 text-[var(--text-dark)]">
+              <strong class="text-[var(--primary)]">Thème :</strong>
+              <span class="inline-block px-2 py-1 rounded-full bg-[var(--surface-alt)] text-[var(--accent-strong)]">
+                {{ academic.theme }}
+              </span>
+            </p>
+            <p class="text-sm text-[var(--text-dark)] line-clamp-3 mb-3">{{ academic.summary }}</p>
+            <span class="font-semibold text-[var(--accent-strong)] group-hover:text-[var(--primary)]">Lire →</span>
+          </a>
+        </app-card>
+      </app-list-page-shell>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AcademicListComponent implements OnInit, OnDestroy {
-  /** Shown while any academic list request is in flight */
-  readonly skeletonSlots = [0, 1, 2, 3, 4, 5] as const;
-
   academics$ = this.academicService.getAcademics$();
   isLoading$ = this.academicService.getLoading$();
   error$ = new BehaviorSubject<string | null>(null);
@@ -275,7 +240,4 @@ export class AcademicListComponent implements OnInit, OnDestroy {
     return academic.id;
   }
 
-  trackBySkeletonSlot(index: number, slot: number): number {
-    return slot;
-  }
 }

--- a/src/app/features/reviews/pages/review-list/review-list.component.ts
+++ b/src/app/features/reviews/pages/review-list/review-list.component.ts
@@ -11,9 +11,7 @@ import { FormsModule } from '@angular/forms';
 import { ReviewService } from '../../services/review.service';
 import { Review } from '../../models/review.model';
 import { CardComponent } from '@shared/components/card/card.component';
-import { ReviewCardSkeletonComponent } from '@shared/components/review-card-skeleton/review-card-skeleton.component';
-import { ButtonComponent } from '@shared/components/button/button.component';
-import { PaginationComponent } from '@shared/components/pagination/pagination.component';
+import { ListPageShellComponent } from '@shared/components/list-page-shell/list-page-shell.component';
 import { Subject, takeUntil, BehaviorSubject } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
@@ -30,9 +28,7 @@ import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
     RouterLink,
     FormsModule,
     CardComponent,
-    ReviewCardSkeletonComponent,
-    ButtonComponent,
-    PaginationComponent,
+    ListPageShellComponent,
   ],
   template: `
     <div class="page-container">
@@ -40,21 +36,33 @@ import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
         <h1 class="mb-1 text-3xl font-bold text-[var(--primary)]">Critiques</h1>
       </div>
 
-      <div class="mb-6 pinterest-panel p-4 md:p-5">
-        <h2 class="mb-3 text-lg font-semibold text-[var(--primary)]">Recherche &amp; filtres</h2>
-        <div class="grid grid-cols-1 md:grid-cols-5 gap-4">
+      <app-list-page-shell
+        [loading]="(isLoading$ | async) ?? false"
+        [error]="(error$ | async) ?? null"
+        errorTitle="Erreur lors du chargement des critiques"
+        [isEmpty]="((reviews$ | async)?.length ?? 0) === 0"
+        emptyMessage="Aucune critique trouvée. Essayez d'ajuster vos filtres."
+        [currentPage]="currentPage"
+        [totalPages]="totalPages"
+        [total]="totalItems"
+        [limit]="pageSize"
+        (retryClick)="retryLoadReviews()"
+        (pageChange)="onPaginationChange($event)"
+      >
+        <!-- Filters -->
+        <div filters class="grid grid-cols-1 md:grid-cols-5 gap-4">
           <input
             type="text"
             placeholder="Rechercher une critique..."
             [(ngModel)]="searchQuery"
             (ngModelChange)="onSearchQueryInput()"
-            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-[var(--input-bg)]"
             aria-label="Rechercher une critique"
           />
           <select
             [(ngModel)]="selectedGenre"
             (change)="onFilterChange()"
-            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-[var(--input-bg)]"
             aria-label="Filtrer par genre"
           >
             <option value="">Tous les genres</option>
@@ -66,7 +74,7 @@ import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
           <select
             [(ngModel)]="selectedRating"
             (change)="onFilterChange()"
-            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-[var(--input-bg)]"
             aria-label="Filtrer par note"
           >
             <option value="">Toutes les notes</option>
@@ -77,7 +85,7 @@ import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
           <select
             [(ngModel)]="selectedSort"
             (change)="onFilterChange()"
-            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-white"
+            class="border border-[var(--border-light)] rounded-xl px-3 py-2 bg-[var(--input-bg)]"
             aria-label="Trier les critiques"
           >
             <option value="">Trier par</option>
@@ -88,50 +96,23 @@ import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
           </select>
           <button
             (click)="resetFilters()"
-            class="bg-white text-[var(--primary)] border border-[var(--border-light)] rounded-full px-3 py-2 hover:bg-[var(--surface-alt)]"
+            class="bg-[var(--input-bg)] text-[var(--primary)] border border-[var(--border-light)] rounded-full px-3 py-2 hover:bg-[var(--surface-alt)]"
           >
             Réinitialiser
           </button>
         </div>
-      </div>
 
-      <!-- Error State -->
-      <ng-container *ngIf="error$ | async as listError">
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-6" role="alert">
-          <p class="font-bold mb-2">Erreur lors du chargement des critiques</p>
-          <p class="text-sm mb-3">{{ listError }}</p>
-          <button (click)="retryLoadReviews()" class="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700">
-            Réessayer
-          </button>
-        </div>
-      </ng-container>
-
-      <div [attr.aria-busy]="(isLoading$ | async) === true" aria-live="polite">
-        <!-- Loading placeholders (filters/pagination stay usable) -->
-        <div
-          *ngIf="isLoading$ | async"
-          class="columns-1 md:columns-2 xl:columns-3 gap-6 space-y-6"
-        >
-          <app-review-card-skeleton
-            *ngFor="let s of skeletonSlots; trackBy: trackBySkeletonSlot"
-          ></app-review-card-skeleton>
-        </div>
-
-        <!-- Reviews List -->
-        <div
-          *ngIf="(isLoading$ | async) === false && (error$ | async) === null"
-          class="columns-1 md:columns-2 xl:columns-3 gap-6 space-y-6"
-        >
+        <!-- Review cards -->
         <app-card
+          items
           *ngFor="let review of reviews$ | async; trackBy: trackByReviewId"
           [hoverable]="true"
           class="break-inside-avoid block mb-6"
         >
-          <!-- Single block link (option A): one focus target per card, no nested links -->
           <a
-            [routerLink]="['/reviews', review.id]"
+            [routerLink]="['\/reviews', review.id]"
             class="group -m-1 block rounded-xl p-1 no-underline outline-none ring-[var(--accent)] transition focus-visible:ring-2"
-            [attr.aria-label]="'Ouvrir la critique : ' + review.title"
+            [attr.aria-label]="'Ouvrir la critique : ' + review.title"
           >
             <h3 class="text-xl font-semibold mb-2 text-[var(--primary)] group-hover:text-[var(--accent-strong)]">
               {{ review.title }}
@@ -153,31 +134,12 @@ import { mapErrorToUserMessage } from '@core/utils/http-error.utils';
             <span class="font-semibold text-[var(--accent-strong)] group-hover:text-[var(--primary)]">Lire →</span>
           </a>
         </app-card>
-        </div>
-      </div>
-
-      <!-- No Results -->
-      <div *ngIf="(reviews$ | async)?.length === 0 && (isLoading$ | async) === false && (error$ | async) === null" class="text-center py-12">
-        <p class="text-xl text-[var(--text-muted)]">Aucune critique trouvée. Essayez d'ajuster vos filtres.</p>
-      </div>
-
-      <!-- Pagination -->
-      <app-pagination
-        *ngIf="(isLoading$ | async) === false && totalItems > 0"
-        [currentPage]="currentPage"
-        [totalPages]="totalPages"
-        [total]="totalItems"
-        [limit]="pageSize"
-        (pageChange)="onPaginationChange($event)"
-      ></app-pagination>
+      </app-list-page-shell>
     </div>
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ReviewListComponent implements OnInit, OnDestroy {
-  /** Shown while any review list request is in flight (initial load, filters, pagination) */
-  readonly skeletonSlots = [0, 1, 2, 3, 4, 5] as const;
-
   reviews$ = this.reviewService.getReviews$();
   isLoading$ = this.reviewService.getLoading$();
   error$ = new BehaviorSubject<string | null>(null);
@@ -302,8 +264,5 @@ export class ReviewListComponent implements OnInit, OnDestroy {
     return review.id;
   }
 
-  trackBySkeletonSlot(index: number, slot: number): number {
-    return slot;
-  }
 }
 

--- a/src/app/shared/components/list-page-shell/list-page-shell.component.ts
+++ b/src/app/shared/components/list-page-shell/list-page-shell.component.ts
@@ -1,0 +1,126 @@
+import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReviewCardSkeletonComponent } from '@shared/components/review-card-skeleton/review-card-skeleton.component';
+import { PaginationComponent } from '@shared/components/pagination/pagination.component';
+
+/**
+ * ListPageShellComponent
+ *
+ * Shared layout shell for paginated list pages (reviews, academics).
+ * Handles the repeated concerns via content projection:
+ * - Loading skeleton placeholders
+ * - Error banner with retry
+ * - Empty-state message
+ * - Pagination footer
+ *
+ * Usage:
+ * ```html
+ * <app-list-page-shell [loading]="..." [error]="..." [isEmpty]="..." ...>
+ *   <div filters class="grid ..."><!-- filter controls --></div>
+ *   <ng-container items><!-- *ngFor card list --></ng-container>
+ * </app-list-page-shell>
+ * ```
+ */
+@Component({
+  selector: 'app-list-page-shell',
+  standalone: true,
+  imports: [CommonModule, ReviewCardSkeletonComponent, PaginationComponent],
+  template: `
+    <!-- Filters panel -->
+    <div class="mb-6 pinterest-panel p-4 md:p-5">
+      <h2 class="mb-3 text-lg font-semibold text-[var(--primary)]">Recherche &amp; filtres</h2>
+      <ng-content select="[filters]"></ng-content>
+    </div>
+
+    <!-- Error banner -->
+    <div
+      *ngIf="error"
+      class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-6"
+      role="alert"
+    >
+      <p class="font-bold mb-2">{{ errorTitle }}</p>
+      <p class="text-sm mb-3">{{ error }}</p>
+      <button
+        (click)="retryClick.emit()"
+        class="bg-red-600 text-white px-4 py-2 rounded-lg hover:bg-red-700"
+      >
+        Réessayer
+      </button>
+    </div>
+
+    <!-- Loading / items area -->
+    <div [attr.aria-busy]="loading" aria-live="polite">
+      <!-- Skeleton placeholders -->
+      <div
+        *ngIf="loading"
+        class="columns-1 md:columns-2 xl:columns-3 gap-6 space-y-6"
+        aria-hidden="true"
+      >
+        <app-review-card-skeleton
+          *ngFor="let s of skeletonSlots; trackBy: trackByIndex"
+        ></app-review-card-skeleton>
+      </div>
+
+      <!-- Projected item cards -->
+      <div
+        *ngIf="!loading && !error"
+        class="columns-1 md:columns-2 xl:columns-3 gap-6 space-y-6"
+      >
+        <ng-content select="[items]"></ng-content>
+      </div>
+    </div>
+
+    <!-- Empty state -->
+    <div
+      *ngIf="isEmpty && !loading && !error"
+      class="text-center py-12"
+    >
+      <p class="text-xl text-[var(--text-muted)]">{{ emptyMessage }}</p>
+    </div>
+
+    <!-- Pagination -->
+    <app-pagination
+      *ngIf="!loading && total > 0"
+      [currentPage]="currentPage"
+      [totalPages]="totalPages"
+      [total]="total"
+      [limit]="limit"
+      (pageChange)="pageChange.emit($event)"
+    ></app-pagination>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ListPageShellComponent {
+  /** True while data is being fetched. Shows skeleton placeholders. */
+  @Input() loading = false;
+
+  /** Error message to display in the error banner. Null = no error. */
+  @Input() error: string | null = null;
+
+  /** Title line for the error banner. */
+  @Input() errorTitle = 'Erreur lors du chargement';
+
+  /** True when the loaded data set is empty (after loading, no error). */
+  @Input() isEmpty = false;
+
+  /** Text shown in the empty state. */
+  @Input() emptyMessage = 'Aucun résultat. Essayez d\'ajuster vos filtres.';
+
+  /** Pagination inputs */
+  @Input() currentPage = 1;
+  @Input() totalPages = 0;
+  @Input() total = 0;
+  @Input() limit = 10;
+
+  /** Emitted when the user clicks the retry button in the error banner. */
+  @Output() retryClick = new EventEmitter<void>();
+
+  /** Emitted when the user changes page. Passes PaginationComponent's event. */
+  @Output() pageChange = new EventEmitter<{ page: number; limit: number }>();
+
+  readonly skeletonSlots = [0, 1, 2, 3, 4, 5];
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+}


### PR DESCRIPTION
## Summary

Implements issue #59 — extracts the duplicated list page layout (error banner, skeleton grid, empty state, pagination) into a reusable `ListPageShellComponent` using Angular content projection.

## New component

`src/app/shared/components/list-page-shell/list-page-shell.component.ts`

### Inputs
| Input | Type | Description |
|-------|------|-------------|
| `loading` | `boolean` | Show skeleton placeholders |
| `error` | `string\|null` | Error banner message |
| `errorTitle` | `string` | Error banner title |
| `isEmpty` | `boolean` | Show empty state |
| `emptyMessage` | `string` | Empty state text |
| `currentPage/totalPages/total/limit` | `number` | Pagination |

### Outputs
- `retryClick` — retry button clicked
- `pageChange` — pagination event

### Content slots
- `[filters]` — filter controls (projected in the filters panel)
- `[items]` — item cards (projected in the items grid, hidden during loading/error)

## Changes to existing components

Both `ReviewListComponent` and `AcademicListComponent`:
- Removed ~80 lines of duplicated HTML (error/skeleton/empty/pagination)
- Now use `<app-list-page-shell>` with the two content slots
- Also fixed `bg-white` → `bg-[var(--input-bg)]` for dark mode compat

## Validation
- ✅ 180/180 tests pass
- ✅ Build OK

Closes #59